### PR TITLE
perf(derive): Prevent duplicate batch validity checks

### DIFF
--- a/crates/derive/src/types/batch/validity.rs
+++ b/crates/derive/src/types/batch/validity.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// Batch Validity
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BatchValidity {
     /// The batch is invalid now and in the future, unless we reorg
     Drop,


### PR DESCRIPTION
## Overview

Prevents duplicate batch validity checks by caching the result of the first check in the `BatchWithInclusionBlock` type. If the validity has already been determined, it will be returned immediately rather than repeating the work.
