### PR TITLE
feat(client): Walkback Channel Timeout in Sad Path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7238,7 +7238,7 @@ dependencies = [
 
 [[package]]
 name = "trusted-sync"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix-web",
  "alloy-primitives",

--- a/bin/kt/src/dn/driver.rs
+++ b/bin/kt/src/dn/driver.rs
@@ -59,6 +59,9 @@ pub(crate) async fn run(
                     error!(target: "loop", "Error stepping derivation pipeline: {:?}", e);
                 }
             },
+            StepResult::FailedToDecodeBatch => {
+                error!(target: "loop", "Failed to decode batch");
+            }
         }
 
         // Take the next attributes from the pipeline.

--- a/crates/derive/src/batch/mod.rs
+++ b/crates/derive/src/batch/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains the batch types for the OP Stack derivation pipeline: [SpanBatch] &
 //! [SingleBatch].
 
+use alloc::boxed::Box;
 use alloy_rlp::{Buf, Decodable};
 use kona_primitives::{block::BlockInfo, L2BlockInfo, RollupConfig};
 
@@ -65,7 +66,7 @@ pub enum Batch {
     /// A single batch
     Single(SingleBatch),
     /// Span Batches
-    Span(SpanBatch),
+    Span(Box<SpanBatch>),
 }
 
 impl Batch {
@@ -98,7 +99,7 @@ impl Batch {
                 let span_batch = raw_span_batch
                     .derive(cfg.block_time, cfg.genesis.l2_time, cfg.l2_chain_id)
                     .map_err(DecodeError::SpanBatchError)?;
-                Ok(Batch::Span(span_batch))
+                Ok(Batch::Span(Box::new(span_batch)))
             }
         }
     }

--- a/crates/derive/src/errors.rs
+++ b/crates/derive/src/errors.rs
@@ -33,6 +33,8 @@ pub enum StageError {
     ChannelNotFound,
     /// Missing L1 origin.
     MissingOrigin,
+    /// Failed to decode a batch from channel data.
+    FailedToDecodeBatch,
     /// Failed to build the [L2PayloadAttributes] for the next batch.
     ///
     /// [L2PayloadAttributes]: kona_primitives::L2PayloadAttributes
@@ -65,6 +67,7 @@ impl PartialEq<StageError> for StageError {
         matches!(
             (self, other),
             (StageError::Eof, StageError::Eof) |
+                (StageError::FailedToDecodeBatch, StageError::FailedToDecodeBatch) |
                 (StageError::Temporary(_), StageError::Temporary(_)) |
                 (StageError::Critical(_), StageError::Critical(_)) |
                 (StageError::NotEnoughData, StageError::NotEnoughData) |
@@ -99,6 +102,7 @@ impl Display for StageError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             StageError::Eof => write!(f, "End of file"),
+            StageError::FailedToDecodeBatch => write!(f, "Failed to decode batch"),
             StageError::Temporary(e) => write!(f, "Temporary error: {}", e),
             StageError::Critical(e) => write!(f, "Critical error: {}", e),
             StageError::NotEnoughData => write!(f, "Not enough data"),

--- a/crates/derive/src/pipeline/core.rs
+++ b/crates/derive/src/pipeline/core.rs
@@ -115,6 +115,15 @@ where
                 }
                 StepResult::AdvancedOrigin
             }
+            Err(StageError::FailedToDecodeBatch) => {
+                // Bubble up the batch decoding error so that the client
+                // may attempt to re-run derivation starting `channel_timeout`
+                // L1 blocks before the l1 origin. This follows consensus as
+                // opposed to batcher policy which attempts to open and
+                // close a channel within a single L1 block.
+                trace!(target: "pipeline", "Pipeline failed to decode batch");
+                StepResult::FailedToDecodeBatch
+            }
             Err(err) => {
                 warn!(target: "pipeline", "Attributes queue step failed: {:?}", err);
                 StepResult::StepFailed(err)

--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -346,6 +346,7 @@ where
             Err(StageError::Eof) => out_of_data = true,
             Err(e) => {
                 crate::timer!(DISCARD, timer);
+                // Bubbles up any other errors like batches failing to be decoded.
                 return Err(e);
             }
         }
@@ -506,7 +507,7 @@ mod tests {
         let mut reader = new_batch_reader();
         let cfg = Arc::new(RollupConfig::default());
         let mut batch_vec: Vec<StageResult<Batch>> = vec![];
-        while let Some(batch) = reader.next_batch(cfg.as_ref()) {
+        while let Ok(batch) = reader.next_batch(cfg.as_ref()) {
             batch_vec.push(Ok(batch));
         }
         let mut mock = MockBatchQueueProvider::new(batch_vec);
@@ -546,7 +547,7 @@ mod tests {
         let mut batch_vec: Vec<StageResult<Batch>> = vec![];
         let mut batch_txs: Vec<Bytes> = vec![];
         let mut second_batch_txs: Vec<Bytes> = vec![];
-        while let Some(batch) = reader.next_batch(cfg.as_ref()) {
+        while let Ok(batch) = reader.next_batch(cfg.as_ref()) {
             if let Batch::Span(span) = &batch {
                 let bys = span.batches[0]
                     .transactions

--- a/crates/derive/src/traits/pipeline.rs
+++ b/crates/derive/src/traits/pipeline.rs
@@ -19,6 +19,8 @@ pub enum StepResult {
     OriginAdvanceErr(StageError),
     /// Step failed.
     StepFailed(StageError),
+    /// Failed to decode a batch.
+    FailedToDecodeBatch,
 }
 
 /// This trait defines the interface for interacting with the derivation pipeline.

--- a/examples/trusted-sync/Cargo.toml
+++ b/examples/trusted-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusted-sync"
-version = "0.1.0"
+version = "0.1.1"
 publish = false
 description = "Derives and validates payloads using a trusted source"
 edition.workspace = true

--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -225,6 +225,10 @@ async fn sync(cli: cli::Cli) -> Result<()> {
                     error!(target: "loop", "Error stepping derivation pipeline: {:?}", e);
                 }
             },
+            StepResult::FailedToDecodeBatch => {
+                metrics::PIPELINE_STEPS.with_label_values(&["failed_to_decode_batch"]).inc();
+                warn!(target: "loop", "Failed to decode batch");
+            }
         }
 
         // Peek at the next prepared attributes and validate them.


### PR DESCRIPTION
**Description**

An alternative to #424 that walks back the `channel_timeout` in the sad path when the pipeline fails to decode a batch from ready channel data.

**Metadata**

Fixes #417 