### PR TITLE
feat: enable `kzg-rs` by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5759,6 +5759,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "k256",
+ "kzg-rs",
  "once_cell",
  "p256",
  "revm-primitives 8.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ alloy-rlp = { version = "0.3.5", default-features = false }
 alloy-consensus = { version = "0.2", default-features = false }
 op-alloy-consensus = { version = "0.1.4", default-features = false }
 alloy-eips = { version = "0.2", default-features = false }
-revm = { git = "https://github.com/bluealloy/revm", version = "13.0", default-features = false }
+revm = { git = "https://github.com/bluealloy/revm", version = "13.0", default-features = false, features = ["kzg-rs"] }
 
 [profile.dev]
 opt-level = 1


### PR DESCRIPTION
**Description**

Enable `kzg-rs` feature on `revm` so KZG point evaluation does not panic by default in the zkVM context.

In Kona, there is an FPVM override for KZG point evaluation (`c-kzg` is expensive in the FPVM context) to ensure that the executor doesn't panic. 

In the zkVM context, we also noticed `c-kzg` was expensive, so we created a feature to enable the usage `kzg-rs` in `revm` (we have an accelerated version of `kzg-rs` we apply as a patch). This won't impact the FPVM as you override the precompile anyways, but it'd be nice for us to not need to explicitly override the precompile in [`op-succinct`](https://github.com/succinctlabs/op-succinct).

**Additional context**

[`kzg-rs` feature flag in `revm`](https://github.com/bluealloy/revm/pull/1558)

FPVM KZG Point Evaluation
https://github.com/ethereum-optimism/kona/blob/d1b63f8c1f6dba67ef922761e39beb86ddfd5291/bin/client/src/fault/precompiles/kzg_point_eval.rs#L16
