### PR TITLE
feat(host): Use `RocksDB` as the disk K/V store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,7 +966,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.75",
+ "syn 2.0.77",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,7 +2522,6 @@ dependencies = [
  "glob",
  "libc",
  "libz-sys",
- "zstd-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.75",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1115,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "c-kzg"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1155,15 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -1157,6 +1197,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -2348,6 +2399,7 @@ dependencies = [
  "os_pipe",
  "reqwest",
  "revm",
+ "rocksdb",
  "serde",
  "serde_json",
  "tokio",
@@ -2431,16 +2483,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.16.0+8.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linked_list_allocator"
@@ -2531,6 +2625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2598,6 +2698,16 @@ dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3547,6 +3657,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "ruint"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3581,6 +3701,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,9 @@ revm = { version = "14.0", default-features = false }
 superchain = "0.3"
 superchain-primitives = { version = "0.3", default-features = false }
 
+# K/V database
+rocksdb = { version = "0.22", default-features = false, features = ["zstd"] }
+
 # Alloy
 alloy-rlp = { version = "0.3", default-features = false }
 alloy-trie = { version = "0.5", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ superchain = "0.3"
 superchain-primitives = { version = "0.3", default-features = false }
 
 # K/V database
-rocksdb = { version = "0.22", default-features = false, features = ["zstd"] }
+rocksdb = { version = "0.22", default-features = false, features = ["snappy"] }
 
 # Alloy
 alloy-rlp = { version = "0.3", default-features = false }

--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -41,3 +41,4 @@ serde_json.workspace = true
 tracing-subscriber.workspace = true
 command-fds.workspace = true
 os_pipe.workspace = true
+rocksdb.workspace = true

--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -549,8 +549,7 @@ where
         // `ProofRetainer` in the event that there are no leaves inserted.
         if nodes.is_empty() {
             let empty_key = PreimageKey::new(*EMPTY_ROOT_HASH, PreimageKeyType::Keccak256);
-            kv_write_lock.set(empty_key.into(), [EMPTY_STRING_CODE].into());
-            return Ok(())
+            return kv_write_lock.set(empty_key.into(), [EMPTY_STRING_CODE].into())
         }
 
         let mut hb = kona_mpt::ordered_trie_with_encoder(nodes, |node, buf| {

--- a/bin/host/src/kv/disk.rs
+++ b/bin/host/src/kv/disk.rs
@@ -1,7 +1,5 @@
-//! Contains a concrete implementation of the [KeyValueStore] trait that stores data on disk.
-//!
-//! Data is stored in a directory, with a separate file for each key. The key is the filename, and
-//! the value is the raw contents of the file.
+//! Contains a concrete implementation of the [KeyValueStore] trait that stores data on disk
+//! using [rocksdb].
 
 use super::KeyValueStore;
 use anyhow::{anyhow, Result};
@@ -27,7 +25,7 @@ impl DiskKeyValueStore {
     /// Gets the [Options] for the underlying RocksDB instance.
     fn get_db_options() -> Options {
         let mut options = Options::default();
-        options.set_compression_type(rocksdb::DBCompressionType::Zstd);
+        options.set_compression_type(rocksdb::DBCompressionType::Snappy);
         options.create_if_missing(true);
         options
     }

--- a/bin/host/src/kv/disk.rs
+++ b/bin/host/src/kv/disk.rs
@@ -4,32 +4,47 @@
 //! the value is the raw contents of the file.
 
 use super::KeyValueStore;
-use alloy_primitives::hex;
-use std::{fs, path::PathBuf};
+use anyhow::{anyhow, Result};
+use rocksdb::{Options, DB};
+use std::path::PathBuf;
 
 /// A simple, synchronous key-value store that stores data on disk.
-#[derive(Default, Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub struct DiskKeyValueStore {
     data_directory: PathBuf,
+    db: DB,
 }
 
 impl DiskKeyValueStore {
     /// Create a new [DiskKeyValueStore] with the given data directory.
     pub fn new(data_directory: PathBuf) -> Self {
-        Self { data_directory }
+        let db = DB::open(&Self::get_db_options(), data_directory.as_path())
+            .unwrap_or_else(|e| panic!("Failed to open database at {data_directory:?}: {e}"));
+
+        Self { data_directory, db }
+    }
+
+    /// Gets the [Options] for the underlying RocksDB instance.
+    fn get_db_options() -> Options {
+        let mut options = Options::default();
+        options.set_compression_type(rocksdb::DBCompressionType::Zstd);
+        options.create_if_missing(true);
+        options
     }
 }
 
 impl KeyValueStore for DiskKeyValueStore {
     fn get(&self, key: alloy_primitives::B256) -> Option<Vec<u8>> {
-        let path = self.data_directory.join(format!("{}.bin", hex::encode(key)));
-        fs::create_dir_all(&self.data_directory).ok()?;
-        fs::read(path).ok()
+        self.db.get(*key).ok()?
     }
 
-    fn set(&mut self, key: alloy_primitives::B256, value: Vec<u8>) {
-        let path = self.data_directory.join(format!("{}.bin", hex::encode(key)));
-        fs::create_dir_all(&self.data_directory).expect("Failed to create directory");
-        fs::write(path, value.as_slice()).expect("Failed to write data to disk");
+    fn set(&mut self, key: alloy_primitives::B256, value: Vec<u8>) -> Result<()> {
+        self.db.put(*key, value).map_err(|e| anyhow!("Failed to set key-value pair: {}", e))
+    }
+}
+
+impl Drop for DiskKeyValueStore {
+    fn drop(&mut self) {
+        let _ = DB::destroy(&Self::get_db_options(), self.data_directory.as_path());
     }
 }

--- a/bin/host/src/kv/local.rs
+++ b/bin/host/src/kv/local.rs
@@ -3,6 +3,7 @@
 use super::KeyValueStore;
 use crate::cli::HostCli;
 use alloy_primitives::B256;
+use anyhow::Result;
 use kona_client::boot::{
     L1_HEAD_KEY, L2_CHAIN_ID_KEY, L2_CLAIM_BLOCK_NUMBER_KEY, L2_CLAIM_KEY, L2_OUTPUT_ROOT_KEY,
     L2_ROLLUP_CONFIG_KEY,
@@ -40,7 +41,7 @@ impl KeyValueStore for LocalKeyValueStore {
         }
     }
 
-    fn set(&mut self, _: B256, _: Vec<u8>) {
+    fn set(&mut self, _: B256, _: Vec<u8>) -> Result<()> {
         unreachable!("LocalKeyValueStore is read-only")
     }
 }

--- a/bin/host/src/kv/mem.rs
+++ b/bin/host/src/kv/mem.rs
@@ -2,6 +2,7 @@
 
 use super::KeyValueStore;
 use alloy_primitives::B256;
+use anyhow::Result;
 use std::collections::HashMap;
 
 /// A simple, synchronous key-value store that stores data in memory. This is useful for testing and
@@ -23,7 +24,8 @@ impl KeyValueStore for MemoryKeyValueStore {
         self.store.get(&key).cloned()
     }
 
-    fn set(&mut self, key: B256, value: Vec<u8>) {
+    fn set(&mut self, key: B256, value: Vec<u8>) -> Result<()> {
         self.store.insert(key, value);
+        Ok(())
     }
 }

--- a/bin/host/src/kv/mod.rs
+++ b/bin/host/src/kv/mod.rs
@@ -1,6 +1,7 @@
 //! This module contains the [KeyValueStore] trait and concrete implementations of it.
 
 use alloy_primitives::B256;
+use anyhow::Result;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -25,5 +26,5 @@ pub trait KeyValueStore {
     fn get(&self, key: B256) -> Option<Vec<u8>>;
 
     /// Set the value associated with the given key.
-    fn set(&mut self, key: B256, value: Vec<u8>);
+    fn set(&mut self, key: B256, value: Vec<u8>) -> Result<()>;
 }

--- a/bin/host/src/kv/split.rs
+++ b/bin/host/src/kv/split.rs
@@ -1,10 +1,10 @@
 //! Contains a concrete implementation of the [KeyValueStore] trait that splits between two separate
 //! [KeyValueStore]s depending on [PreimageKeyType].
 
-use alloy_primitives::B256;
-use kona_preimage::PreimageKeyType;
-
 use super::KeyValueStore;
+use alloy_primitives::B256;
+use anyhow::Result;
+use kona_preimage::PreimageKeyType;
 
 /// A split implementation of the [KeyValueStore] trait that splits between two separate
 /// [KeyValueStore]s.
@@ -41,7 +41,7 @@ where
         }
     }
 
-    fn set(&mut self, key: B256, value: Vec<u8>) {
-        self.remote_store.set(key, value);
+    fn set(&mut self, key: B256, value: Vec<u8>) -> Result<()> {
+        self.remote_store.set(key, value)
     }
 }


### PR DESCRIPTION
## Overview

Updates the disk K/V store to use [`rocksdb`](https://github.com/facebook/rocksdb). The old method was extremely inefficient on iops and compression. While the disk-backed K/V store isn't really in the hot path, having a more compression-friendly format is very convenient for testing.
