### PR TITLE
chore(ci): Configure codecov patch job

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -10,6 +10,13 @@ coverage:
       default:
         # Avoid false negatives
         threshold: 1%
+    patch:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+        base: auto 
+        only_pulls: true
 
 ignore:
   - "tests"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,7 +1,6 @@
 # ref: https://docs.codecov.com/docs/codecovyml-reference
 coverage:
-  # TODO: Raise coverage requirements
-  range: 25..100
+  range: 75..100
   round: down
   precision: 1
   status:
@@ -12,9 +11,9 @@ coverage:
         threshold: 1%
     patch:
       default:
-        # basic
         target: auto
-        threshold: 0%
+        # Avoid false negatives
+        threshold: 1%
         base: auto 
         only_pulls: true
 


### PR DESCRIPTION
## Overview

Configures the codecov patch job to only run on pull requests, + raises required coverage to 75%.