### PR TITLE
fix(host): Insert empty MPT root hash

### DIFF
--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -540,8 +540,8 @@ where
         let mut kv_write_lock = self.kv_store.write().await;
 
         // If the list of nodes is empty, store the empty root hash and exit early.
-        // The `HashBuilder` will not push the preimage of the empty root hash to the `ProofRetainer`
-        // in the event that there are no leaves inserted.
+        // The `HashBuilder` will not push the preimage of the empty root hash to the
+        // `ProofRetainer` in the event that there are no leaves inserted.
         if nodes.is_empty() {
             let empty_key = PreimageKey::new(*EMPTY_ROOT_HASH, PreimageKeyType::Keccak256);
             kv_write_lock.set(empty_key.into(), [EMPTY_STRING_CODE].into());

--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -2,11 +2,11 @@
 //! remote source.
 
 use crate::{kv::KeyValueStore, util};
-use alloy_consensus::{Header, TxEnvelope};
+use alloy_consensus::{Header, TxEnvelope, EMPTY_ROOT_HASH};
 use alloy_eips::{eip2718::Encodable2718, eip4844::FIELD_ELEMENTS_PER_BLOB, BlockId};
 use alloy_primitives::{address, keccak256, Address, Bytes, B256};
 use alloy_provider::{Provider, ReqwestProvider};
-use alloy_rlp::Decodable;
+use alloy_rlp::{Decodable, EMPTY_STRING_CODE};
 use alloy_rpc_types::{
     Block, BlockNumberOrTag, BlockTransactions, BlockTransactionsKind, Transaction,
 };
@@ -537,13 +537,22 @@ where
     /// Stores intermediate trie nodes in the key-value store. Assumes that all nodes passed are
     /// raw, RLP encoded trie nodes.
     async fn store_trie_nodes<T: AsRef<[u8]>>(&self, nodes: &[T]) -> Result<()> {
+        let mut kv_write_lock = self.kv_store.write().await;
+
+        // If the list of nodes is empty, store the empty root hash and exit early.
+        // The `HashBuilder` will not push the preimage of the empty root hash to the `ProofRetainer`
+        // in the event that there are no leaves inserted.
+        if nodes.is_empty() {
+            let empty_key = PreimageKey::new(*EMPTY_ROOT_HASH, PreimageKeyType::Keccak256);
+            kv_write_lock.set(empty_key.into(), [EMPTY_STRING_CODE].into());
+            return Ok(())
+        }
+
         let mut hb = kona_mpt::ordered_trie_with_encoder(nodes, |node, buf| {
             buf.put_slice(node.as_ref());
         });
         hb.root();
         let intermediates = hb.take_proofs();
-
-        let mut kv_write_lock = self.kv_store.write().await;
 
         for (_, value) in intermediates.into_iter() {
             let value_hash = keccak256(value.as_ref());


### PR DESCRIPTION
## Overview

Inserts the empty MPT root hash in `store_trie_nodes` if the `nodes` array passed is empty. The `HashBuilder` will not push the preimage of the empty root hash to the `ProofRetainer` if the `nodes` arr is empty.

fixes #399 
