### PR TITLE
fix(OrderedListWalker): Support empty tries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ target/
 
 # Environment Variables
 .env
+
+# IntelliJ IDE
+.idea

--- a/crates/mpt/src/list_walker.rs
+++ b/crates/mpt/src/list_walker.rs
@@ -117,6 +117,9 @@ where
                     node => Ok(Self::fetch_leaves(node, fetcher)?),
                 }
             }
+            TrieNode::Empty => {
+                Ok(Default::default())
+            }
             _ => anyhow::bail!("Invalid trie node type encountered"),
         }
     }

--- a/crates/mpt/src/list_walker.rs
+++ b/crates/mpt/src/list_walker.rs
@@ -159,6 +159,7 @@ where
 mod test {
     use super::*;
     use crate::{
+        NoopTrieDBFetcher,
         ordered_trie_with_encoder,
         test_util::{
             get_live_derivable_receipts_list, get_live_derivable_transactions_list,
@@ -222,6 +223,15 @@ mod test {
                 .map(|(_, v)| { String::decode(&mut v.as_ref()).unwrap() })
                 .collect::<Vec<_>>(),
             VALUES
+        );
+    }
+
+    #[test]
+    fn test_empty_list_walker() {
+        assert!(
+            OrderedListWalker::fetch_leaves(&TrieNode::Empty, &NoopTrieDBFetcher)
+                .expect("Failed to traverse empty trie")
+                .is_empty()
         );
     }
 }


### PR DESCRIPTION
`OrderedListWalker::fetch_leaves` returns an error when traversing an empty trie, since the root node is of type `TrieNode::Empty`.