### PR TITLE
chore(kona-host): type annotations

### DIFF
--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -469,7 +469,7 @@ where
                     let node_hash = keccak256(node.as_ref());
                     let key = PreimageKey::new(*node_hash, PreimageKeyType::Keccak256);
                     kv_write_lock.set(key.into(), node.into())?;
-                    Ok(())
+                    Ok::<(), anyhow::Error>(())
                 })?;
             }
             HintType::L2AccountStorageProof => {
@@ -499,7 +499,7 @@ where
                     let node_hash = keccak256(node.as_ref());
                     let key = PreimageKey::new(*node_hash, PreimageKeyType::Keccak256);
                     kv_write_lock.set(key.into(), node.into())?;
-                    Ok(())
+                    Ok::<(), anyhow::Error>(())
                 })?;
 
                 // Write the storage proof nodes to the key-value store.
@@ -508,7 +508,7 @@ where
                     let node_hash = keccak256(node.as_ref());
                     let key = PreimageKey::new(*node_hash, PreimageKeyType::Keccak256);
                     kv_write_lock.set(key.into(), node.into())?;
-                    Ok(())
+                    Ok::<(), anyhow::Error>(())
                 })?;
             }
         }
@@ -549,7 +549,7 @@ where
         // `ProofRetainer` in the event that there are no leaves inserted.
         if nodes.is_empty() {
             let empty_key = PreimageKey::new(*EMPTY_ROOT_HASH, PreimageKeyType::Keccak256);
-            return kv_write_lock.set(empty_key.into(), [EMPTY_STRING_CODE].into())
+            return kv_write_lock.set(empty_key.into(), [EMPTY_STRING_CODE].into());
         }
 
         let mut hb = kona_mpt::ordered_trie_with_encoder(nodes, |node, buf| {


### PR DESCRIPTION
Consumers of `kona-host` run into cargo type annotation issues. Similar to https://github.com/anton-rs/kona/pull/421.

There must be a way to catch this in `kona`, but after some preliminary testing, I couldn't find an easy fix.