### PR TITLE
feat(driver): Don't panic by default on disputed payload derivation failure

### DIFF
--- a/bin/client/src/kona.rs
+++ b/bin/client/src/kona.rs
@@ -58,10 +58,8 @@ fn main() -> Result<()> {
             l2_provider.clone(),
         )
         .await?;
-        let L2AttributesWithParent { attributes, .. } = driver
-            .produce_disputed_payload()
-            .await?
-            .expect("Failed to derive payload attributes");
+        let L2AttributesWithParent { attributes, .. } =
+            driver.produce_disputed_payload().await?.expect("Failed to derive payload attributes");
 
         let mut executor = StatelessL2BlockExecutor::builder(&boot.rollup_config)
             .with_parent_header(driver.take_l2_safe_head_header())

--- a/bin/client/src/kona.rs
+++ b/bin/client/src/kona.rs
@@ -58,7 +58,10 @@ fn main() -> Result<()> {
             l2_provider.clone(),
         )
         .await?;
-        let L2AttributesWithParent { attributes, .. } = driver.produce_disputed_payload().await?;
+        let L2AttributesWithParent { attributes, .. } = driver
+            .produce_disputed_payload()
+            .await?
+            .expect("Failed to derive payload attributes");
 
         let mut executor = StatelessL2BlockExecutor::builder(&boot.rollup_config)
             .with_parent_header(driver.take_l2_safe_head_header())

--- a/bin/client/src/l1/driver.rs
+++ b/bin/client/src/l1/driver.rs
@@ -151,7 +151,7 @@ where
 
     /// Produces the disputed [L2AttributesWithParent] payload, directly after the starting L2
     /// output root passed through the [BootInfo].
-    pub async fn produce_disputed_payload(&mut self) -> Result<L2AttributesWithParent> {
+    pub async fn produce_disputed_payload(&mut self) -> Result<Option<L2AttributesWithParent>> {
         // As we start the safe head at the disputed block's parent, we step the pipeline until the
         // first attributes are produced. All batches at and before the safe head will be
         // dropped, so the first payload will always be the disputed one.
@@ -179,7 +179,7 @@ where
             attributes = self.pipeline.next();
         }
 
-        Ok(attributes.expect("Failed to derive payload attributes"))
+        Ok(attributes)
     }
 
     /// Finds the startup information for the derivation pipeline.


### PR DESCRIPTION
This PR enables the client to customize how it handles a failure by `DerivationDriver::produce_disputed_payload` due to `StageError::NotEnoughData`. This would enable a `no_std` client to handle that an output cannot be derived from the available L1 data without panic handling.