### PR TITLE
fix(fetcher): Explicit return type to fix inference failure when building `kona-host` as dependency

### DIFF
--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -469,7 +469,7 @@ where
                     let node_hash = keccak256(node.as_ref());
                     let key = PreimageKey::new(*node_hash, PreimageKeyType::Keccak256);
                     kv_write_lock.set(key.into(), node.into())?;
-                    Ok(())
+                    Ok::<(), anyhow::Error>(())
                 })?;
             }
             HintType::L2AccountStorageProof => {
@@ -499,7 +499,7 @@ where
                     let node_hash = keccak256(node.as_ref());
                     let key = PreimageKey::new(*node_hash, PreimageKeyType::Keccak256);
                     kv_write_lock.set(key.into(), node.into())?;
-                    Ok(())
+                    Ok::<(), anyhow::Error>(())
                 })?;
 
                 // Write the storage proof nodes to the key-value store.
@@ -508,7 +508,7 @@ where
                     let node_hash = keccak256(node.as_ref());
                     let key = PreimageKey::new(*node_hash, PreimageKeyType::Keccak256);
                     kv_write_lock.set(key.into(), node.into())?;
-                    Ok(())
+                    Ok::<(), anyhow::Error>(())
                 })?;
             }
         }


### PR DESCRIPTION
This PR fixes a build failure that occurs when using `kona-host` as a dependency.