### PR TITLE
feat: expose `MemoryKeyValueStore` store

### DIFF
--- a/bin/host/src/kv/mem.rs
+++ b/bin/host/src/kv/mem.rs
@@ -9,7 +9,8 @@ use std::collections::HashMap;
 /// development purposes.
 #[derive(Default, Clone, Debug, Eq, PartialEq)]
 pub struct MemoryKeyValueStore {
-    store: HashMap<B256, Vec<u8>>,
+    /// The underlying store.
+    pub store: HashMap<B256, Vec<u8>>,
 }
 
 impl MemoryKeyValueStore {


### PR DESCRIPTION
Consumers of `kona` such as `op-succinct` need access to the underlying store for operations like zero-copy serialization. 

Specifically, `alloy-primitives` doesn't derive `rkyv`'s macros on types, and to reduce the cycle count for reading data into the zkVM, we convert the store keys from `B256` to `[u8; 32]`, which we can then serialize/deserialize with `rkyv`.