### PR TITLE
feat(host): Exit with client status in native mode

### DIFF
--- a/bin/client/src/kona.rs
+++ b/bin/client/src/kona.rs
@@ -74,8 +74,21 @@ fn main() -> Result<()> {
         //                          EPILOGUE                          //
         ////////////////////////////////////////////////////////////////
 
-        assert_eq!(number, boot.l2_claim_block);
-        assert_eq!(output_root, boot.l2_claim);
+        if number != boot.l2_claim_block || output_root != boot.l2_claim {
+            tracing::error!(
+                target: "client",
+                "Failed to validate L2 block #{number} with output root {output_root}",
+                number = number,
+                output_root = output_root
+            );
+            kona_common::io::print(&alloc::format!(
+                "Failed to validate L2 block #{} with output root {}\n",
+                number,
+                output_root
+            ));
+
+            kona_common::io::exit(1);
+        }
 
         tracing::info!(
             target: "client",

--- a/bin/host/src/lib.rs
+++ b/bin/host/src/lib.rs
@@ -83,7 +83,8 @@ pub async fn start_server(cfg: HostCli) -> Result<()> {
 ///
 /// ## Returns
 /// - `Ok(exit_code)` if the client program exits successfully.
-/// - `Err(_)` if the client program failed to execute, was killed by a signal, or the host program exited first.
+/// - `Err(_)` if the client program failed to execute, was killed by a signal, or the host program
+///   exited first.
 pub async fn start_server_and_native_client(cfg: HostCli) -> Result<i32> {
     let hint_pipe = util::bidirectional_pipe()?;
     let preimage_pipe = util::bidirectional_pipe()?;

--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use kona_host::{init_tracing_subscriber, start_server, start_server_and_native_client, HostCli};
-use tracing::info;
+use tracing::{error, info};
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
@@ -11,7 +11,13 @@ async fn main() -> Result<()> {
     if cfg.server {
         start_server(cfg).await?;
     } else {
-        let status = start_server_and_native_client(cfg).await?;
+        let status = match start_server_and_native_client(cfg).await {
+            Ok(status) => status,
+            Err(e) => {
+                error!(target: "kona_host", "Exited with an error: {:?}", e);
+                panic!("{e}");
+            }
+        };
 
         // Bubble up the exit status of the client program.
         std::process::exit(status as i32);

--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -11,7 +11,10 @@ async fn main() -> Result<()> {
     if cfg.server {
         start_server(cfg).await?;
     } else {
-        start_server_and_native_client(cfg).await?;
+        let status = start_server_and_native_client(cfg).await?;
+
+        // Bubble up the exit status of the client program.
+        std::process::exit(status as i32);
     }
 
     info!("Exiting host program.");


### PR DESCRIPTION
## Overview

Exits the host program with the client program's status when running in native mode. This ensures that test suites that execute the client program natively can inspect the error that occurred, between `0` (CLAIM_VALID), `1` (CLAIM_INVALID), `2` (PANIC)

closes #527 