### PR TITLE
chore(host): Make `l2-chain-id` optional if a rollup config was passed.

### DIFF
--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -70,7 +70,6 @@ run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbo
   L1_BEACON_ADDRESS="{{l1_beacon_rpc}}"
   L2_NODE_ADDRESS="{{l2_rpc}}"
   OP_NODE_ADDRESS="{{rollup_node_rpc}}"
-  CLIENT_BIN_PATH="./target/riscv64gc-unknown-none-elf/release-client-lto/kona"
 
   L2_BLOCK_NUMBER={{block_number}}
   echo "Fetching configuration for block #$L2_BLOCK_NUMBER..."

--- a/bin/host/src/cli/mod.rs
+++ b/bin/host/src/cli/mod.rs
@@ -5,7 +5,7 @@ use crate::kv::{
     SplitKeyValueStore,
 };
 use alloy_primitives::B256;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, ensure, Result};
 use clap::{ArgAction, Parser};
 use op_alloy_genesis::RollupConfig;
 use serde::Serialize;
@@ -19,7 +19,7 @@ mod tracing_util;
 pub use tracing_util::init_tracing_subscriber;
 
 /// The host binary CLI application arguments.
-#[derive(Parser, Serialize, Clone, Debug)]
+#[derive(Default, Parser, Serialize, Clone, Debug)]
 pub struct HostCli {
     /// Verbosity level (0-4)
     #[arg(long, short, help = "Verbosity level (0-4)", action = ArgAction::Count)]
@@ -41,7 +41,7 @@ pub struct HostCli {
     pub l2_block_number: u64,
     /// The L2 chain ID.
     #[clap(long)]
-    pub l2_chain_id: u64,
+    pub l2_chain_id: Option<u64>,
     /// Address of L2 JSON-RPC endpoint to use (eth and debug namespace required).
     #[clap(long)]
     pub l2_node_address: Option<String>,
@@ -67,6 +67,20 @@ pub struct HostCli {
 }
 
 impl HostCli {
+    /// Validates the CLI arguments.
+    pub fn validate(&self) -> Result<()> {
+        ensure!(
+            !(self.exec.is_some() && self.server),
+            "Cannot run in both server and native modes."
+        );
+        ensure!(
+            !(self.rollup_config_path.is_some() && self.l2_chain_id.is_some()),
+            "Both L2 chain ID and a custom rollup config cannot be supplied."
+        );
+
+        Ok(())
+    }
+
     /// Returns `true` if the host is running in offline mode.
     pub fn is_offline(&self) -> bool {
         self.l1_node_address.is_none() ||
@@ -107,5 +121,27 @@ impl HostCli {
         // Deserialize the config and return it.
         serde_json::from_str(&ser_config)
             .map_err(|e| anyhow!("Error deserializing RollupConfig: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::HostCli;
+
+    #[test]
+    fn test_invalid_cli_server_and_native() {
+        let cli =
+            HostCli { server: true, exec: Some("deaddead".to_string()), ..Default::default() };
+        assert!(cli.validate().is_err());
+    }
+
+    #[test]
+    fn test_invalid_cli_chain_id_and_rollup_config() {
+        let cli = HostCli {
+            l2_chain_id: Some(1),
+            rollup_config_path: Some("deaddead".into()),
+            ..Default::default()
+        };
+        assert!(cli.validate().is_err());
     }
 }

--- a/bin/host/src/kv/local.rs
+++ b/bin/host/src/kv/local.rs
@@ -10,6 +10,9 @@ use kona_client::boot::{
 };
 use kona_preimage::PreimageKey;
 
+/// The default chain ID to use if none is provided.
+const DEFAULT_CHAIN_ID: u64 = 0xbeefbabe;
+
 /// A simple, synchronous key-value store that returns data from a [HostCli] config.
 #[derive(Debug)]
 pub struct LocalKeyValueStore {
@@ -31,7 +34,9 @@ impl KeyValueStore for LocalKeyValueStore {
             L2_OUTPUT_ROOT_KEY => Some(self.cfg.l2_output_root.to_vec()),
             L2_CLAIM_KEY => Some(self.cfg.l2_claim.to_vec()),
             L2_CLAIM_BLOCK_NUMBER_KEY => Some(self.cfg.l2_block_number.to_be_bytes().to_vec()),
-            L2_CHAIN_ID_KEY => Some(self.cfg.l2_chain_id.to_be_bytes().to_vec()),
+            L2_CHAIN_ID_KEY => {
+                Some(self.cfg.l2_chain_id.unwrap_or(DEFAULT_CHAIN_ID).to_be_bytes().to_vec())
+            }
             L2_ROLLUP_CONFIG_KEY => {
                 let rollup_config = self.cfg.read_rollup_config().ok()?;
                 let serialized = serde_json::to_vec(&rollup_config).ok()?;

--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -6,6 +6,7 @@ use tracing::{error, info};
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     let cfg = HostCli::parse();
+    cfg.validate()?;
     init_tracing_subscriber(cfg.v)?;
 
     if cfg.server {


### PR DESCRIPTION
## Overview

> [!NOTE]
> Needs https://github.com/ethereum-optimism/optimism/pull/11951 for CI to pass.

Makes the `l2-chain-id` flag mutually exclusive from the `rollup-config-path` flag.
