### PR TITLE
fix(preimage): Improve error differentiation in preimage servers

### DIFF
--- a/crates/preimage/src/lib.rs
+++ b/crates/preimage/src/lib.rs
@@ -22,7 +22,7 @@ pub use pipe::PipeHandle;
 mod traits;
 pub use traits::{
     CommsClient, HintReaderServer, HintRouter, HintWriterClient, PreimageFetcher,
-    PreimageOracleClient, PreimageOracleServer,
+    PreimageOracleClient, PreimageOracleServer, PreimageServerError,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
## Overview

Improves the differentiation of errors in the preimage server routes. This allows for us to throw on non-pipe related errors, rather than silently fail and assume that the exit is related to a broken pipe.

Also fixes an edge case where if the `HintReaderServer` receives bad UTF-8, it will block forever.
