### PR TITLE
chore: clean up host CLI

### DIFF
--- a/bin/host/Cargo.toml
+++ b/bin/host/Cargo.toml
@@ -16,8 +16,6 @@ kona-common.workspace = true
 kona-preimage.workspace = true
 kona-derive = { workspace = true, features = ["online"] }
 kona-primitives = { workspace = true, features = ["online"] }
-op-alloy-genesis = { workspace = true, features = ["std", "serde"] }
-op-alloy-protocol = { workspace = true, features = ["std", "serde"] }
 
 # Alloy & Revm
 alloy-eips.workspace = true
@@ -28,6 +26,8 @@ alloy-transport-http.workspace = true
 alloy-rpc-client.workspace = true 
 alloy-rpc-types = { workspace = true, features = ["eth"] }
 alloy-primitives = { workspace = true, features = ["serde"] }
+op-alloy-genesis = { workspace = true, features = ["std", "serde"] }
+op-alloy-protocol = { workspace = true, features = ["std", "serde"] }
 revm = { workspace = true, features = ["std", "c-kzg", "secp256k1", "portable", "blst"] }
 
 # General

--- a/bin/host/README.md
+++ b/bin/host/README.md
@@ -11,7 +11,7 @@ kona-host is a CLI application that runs the [pre-image server][p-server] and [c
 
 ## Usage
 
-```
+```txt
 Usage: kona-host [OPTIONS] --l1-head <L1_HEAD> --l2-head <L2_HEAD> --l2-output-root <L2_OUTPUT_ROOT> --l2-claim <L2_CLAIM> --l2-block-number <L2_BLOCK_NUMBER>
 
 Options:

--- a/bin/host/README.md
+++ b/bin/host/README.md
@@ -1,10 +1,53 @@
 # `kona-host`
 
-The host binary's primary role is to serve the client program responses to requests over the [Preimage Oracle ABI][preimage-spec].
+kona-host is a CLI application that runs the [pre-image server][p-server] and [client program][client-program].
 
 ## Modes
 
-| Mode     | Description                                                                                                                                                                                            |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `server` | Starts with the preimage server only, expecting the client program to have been invoked by the host process. This mode is particularly purposed to be activated by the FPVM running the client program |
-| `native` | Starts both the preimage oracle and client program in a native process, bypassing the verifiable FPVM environment. This mode is useful for upfront witness generation as well as testing.              |
+| Mode     | Description                                                                                                                                                                             |
+| -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server` | Starts with the preimage server only, expecting the client program to have been invoked by the host process. This mode is intended for use by the FPVM when running the client program. |
+| `native` | Starts both the preimage oracle and client program in a native process. This mode is useful for witness generation as well as testing.                                                  |
+
+## Usage
+
+```
+Usage: kona-host [OPTIONS] --l1-head <L1_HEAD> --l2-head <L2_HEAD> --l2-output-root <L2_OUTPUT_ROOT> --l2-claim <L2_CLAIM> --l2-block-number <L2_BLOCK_NUMBER>
+
+Options:
+  -v, --v...
+          Verbosity level (0-2)
+      --l1-head <L1_HEAD>
+          Hash of the L1 head block. Derivation stops after this block is processed
+      --l2-head <L2_HEAD>
+          Hash of the L2 block committed to by `--l2-output-root`
+      --l2-output-root <L2_OUTPUT_ROOT>
+          Agreed L2 Output Root to start derivation from
+      --l2-claim <L2_CLAIM>
+          Claimed L2 output root at block # `--l2-block-number` to validate
+      --l2-block-number <L2_BLOCK_NUMBER>
+          Number of the L2 block that the claim commits to
+      --l2-node-address <L2_NODE_ADDRESS>
+          Address of L2 JSON-RPC endpoint to use (eth and debug namespace required) [aliases: l2]
+      --l1-node-address <L1_NODE_ADDRESS>
+          Address of L1 JSON-RPC endpoint to use (eth and debug namespace required) [aliases: l1]
+      --l1-beacon-address <L1_BEACON_ADDRESS>
+          Address of the L1 Beacon API endpoint to use [aliases: beacon]
+      --data-dir <DATA_DIR>
+          The Data Directory for preimage data storage. Default uses in-memory storage [aliases: db]
+      --exec <EXEC>
+          Run the specified client program natively as a separate process detached from the host
+      --server
+          Run in pre-image server mode without executing any client program. If not provided, the host will run the client program in the host process
+      --l2-chain-id <L2_CHAIN_ID>
+          The L2 chain ID of a supported chain. If provided, the host will look for the corresponding rollup config in the superchain registry
+      --rollup-config-path <ROLLUP_CONFIG_PATH>
+          Path to rollup config. If provided, the host will use this config instead of attempting to look up the config in the superchain registry
+  -h, --help
+          Print help
+  -V, --version
+          Print version
+```
+
+[p-server]: https://specs.optimism.io/fault-proof/index.html#pre-image-oracle
+[client-program]: https://specs.optimism.io/fault-proof/index.html#fault-proof-program

--- a/bin/host/src/cli/mod.rs
+++ b/bin/host/src/cli/mod.rs
@@ -80,8 +80,13 @@ pub struct HostCli {
         requires = "l2_node_address"
     )]
     pub l1_beacon_address: Option<String>,
-    /// The Data Directory for preimage data storage. Default uses in-memory storage.
-    #[clap(long, visible_alias = "db")]
+    /// The Data Directory for preimage data storage. Optional if running in online mode,
+    /// required if running in offline mode.
+    #[clap(
+        long,
+        visible_alias = "db",
+        required_unless_present_all = ["l2_node_address", "l1_node_address", "l1_beacon_address"]
+    )]
     pub data_dir: Option<PathBuf>,
     /// Run the specified client program natively as a separate process detached from the host.
     #[clap(long, conflicts_with = "server", required_unless_present = "server")]
@@ -221,10 +226,14 @@ mod test {
 
         let cases = [
             // valid
-            (["--server", "--l2-chain-id", "0"].as_slice(), true),
-            (["--server", "--rollup-config-path", "dummy"].as_slice(), true),
-            (["--exec", "dummy", "--l2-chain-id", "0"].as_slice(), true),
-            (["--exec", "dummy", "--rollup-config-path", "dummy"].as_slice(), true),
+            (["--server", "--l2-chain-id", "0", "--data-dir", "dummy"].as_slice(), true),
+            (["--server", "--rollup-config-path", "dummy", "--data-dir", "dummy"].as_slice(), true),
+            (["--exec", "dummy", "--l2-chain-id", "0", "--data-dir", "dummy"].as_slice(), true),
+            (
+                ["--exec", "dummy", "--rollup-config-path", "dummy", "--data-dir", "dummy"]
+                    .as_slice(),
+                true,
+            ),
             (
                 [
                     "--l1-node-address",

--- a/bin/host/src/cli/mod.rs
+++ b/bin/host/src/cli/mod.rs
@@ -1,9 +1,12 @@
 //! This module contains all CLI-specific code for the host binary.
 
-use crate::{kv::{
-    DiskKeyValueStore, LocalKeyValueStore, MemoryKeyValueStore, SharedKeyValueStore,
-    SplitKeyValueStore,
-}, util};
+use crate::{
+    kv::{
+        DiskKeyValueStore, LocalKeyValueStore, MemoryKeyValueStore, SharedKeyValueStore,
+        SplitKeyValueStore,
+    },
+    util,
+};
 use alloy_primitives::B256;
 use alloy_provider::ReqwestProvider;
 use anyhow::{anyhow, Result};
@@ -77,9 +80,9 @@ pub struct HostCli {
 impl HostCli {
     /// Returns `true` if the host is running in offline mode.
     pub fn is_offline(&self) -> bool {
-        self.l1_node_address.is_none()
-            && self.l2_node_address.is_none()
-            && self.l1_beacon_address.is_none()
+        self.l1_node_address.is_none() &&
+            self.l2_node_address.is_none() &&
+            self.l1_beacon_address.is_none()
     }
 
     /// Creates the providers associated with the [HostCli] configuration.
@@ -207,8 +210,7 @@ mod test {
         ];
 
         for (args_ext, valid) in cases.into_iter() {
-            let args =
-                default_flags.iter().chain(args_ext.into_iter()).cloned().collect::<Vec<_>>();
+            let args = default_flags.iter().chain(args_ext.iter()).cloned().collect::<Vec<_>>();
 
             let parsed = HostCli::try_parse_from(args);
             assert_eq!(parsed.is_ok(), valid);

--- a/bin/host/src/cli/tracing_util.rs
+++ b/bin/host/src/cli/tracing_util.rs
@@ -6,17 +6,15 @@ use tracing::Level;
 /// Initializes the tracing subscriber
 ///
 /// # Arguments
-/// * `verbosity_level` - The verbosity level (0-4)
+/// * `verbosity_level` - The verbosity level (0-2)
 ///
 /// # Returns
 /// * `Result<()>` - Ok if successful, Err otherwise.
 pub fn init_tracing_subscriber(verbosity_level: u8) -> Result<()> {
     let subscriber = tracing_subscriber::fmt()
         .with_max_level(match verbosity_level {
-            0 => Level::ERROR,
-            1 => Level::WARN,
-            2 => Level::INFO,
-            3 => Level::DEBUG,
+            0 => Level::INFO,
+            1 => Level::DEBUG,
             _ => Level::TRACE,
         })
         .finish();

--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -6,7 +6,6 @@ use tracing::{error, info};
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
     let cfg = HostCli::parse();
-    cfg.validate()?;
     init_tracing_subscriber(cfg.v)?;
 
     if cfg.server {


### PR DESCRIPTION
## Overview

Cleans up the host CLI validation by using the native features of the `clap::arg` proc macro over a custom validation function. Also adjusts some of the flag docs to be a bit more helpful.

and, colors, because it's kind of cool 🎨

<img width="1369" alt="Screenshot 2024-09-18 at 3 19 30 AM" src="https://github.com/user-attachments/assets/9e8c7cf1-ed8e-4e0b-9206-a6457a290670">