### PR TITLE
feat(derive): Typed error handling

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -19,8 +19,9 @@ coverage:
 
 ignore:
   - "tests"
-  - "test_util*"
-  - "test_utils"
+  - "test_util.rs"
+  - "test_utils.rs"
+  - "crates/derive/src/stages/test_utils"
   - "bin/"
 
 # Make comments less noisy

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -25,13 +25,20 @@ jobs:
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
       - name: cargo llvm-cov
-        run: cargo llvm-cov nextest --locked --workspace --lcov --output-path lcov.info --features test-utils
+        run: |
+          cargo llvm-cov nextest --locked --workspace --lcov --output-path lcov.info --features test-utils --profile ci && \
+            mv ./target/nextest/ci/junit.xml ./junit.xml
       - name: Record Rust version
         run: echo "RUST=$(rustc --version)" >> "$GITHUB_ENV"
-      - name: Upload to codecov.io
+      - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           env_vars: OS,RUST
           files: lcov.info
+      - name: Upload test results to codecov.io
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
@@ -362,7 +362,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
- "thiserror",
+ "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -389,7 +389,7 @@ dependencies = [
  "rand",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "url",
 ]
@@ -444,7 +444,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tracing",
  "url",
@@ -562,7 +562,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror",
+ "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -635,7 +635,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tower 0.5.1",
  "tracing",
@@ -1276,7 +1276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb11bd1378bf3731b182997b40cefe00aba6a6cc74042c8318c1b271d3badf7"
 dependencies = [
  "nix 0.27.1",
- "thiserror",
+ "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
 ]
 
@@ -2367,6 +2367,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin",
+ "thiserror 1.0.63 (git+https://github.com/quartiq/thiserror?branch=no-std)",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2489,6 +2490,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "thiserror 1.0.63 (git+https://github.com/quartiq/thiserror?branch=no-std)",
  "tracing",
 ]
 
@@ -3090,7 +3092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "ucd-trie",
 ]
 
@@ -3195,7 +3197,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3304,7 +3306,7 @@ dependencies = [
  "parking_lot",
  "procfs",
  "protobuf",
- "thiserror",
+ "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4364,7 +4366,15 @@ version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "git+https://github.com/quartiq/thiserror?branch=no-std#44737a516b7fd0cc9dabcab07e7b1f927f8f5636"
+dependencies = [
+ "thiserror-impl 1.0.63 (git+https://github.com/quartiq/thiserror?branch=no-std)",
 ]
 
 [[package]]
@@ -4372,6 +4382,16 @@ name = "thiserror-impl"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.63"
+source = "git+https://github.com/quartiq/thiserror?branch=no-std#44737a516b7fd0cc9dabcab07e7b1f927f8f5636"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ kona-primitives = { path = "crates/primitives", version = "0.0.2", default-featu
 
 # General
 anyhow = { version = "1.0.86", default-features = false }
+thiserror = { git = "https://github.com/quartiq/thiserror", branch = "no-std", default-features = false }
 cfg-if = "1.0.0"
 hashbrown = "0.14.5"
 spin = { version = "0.9.8", features = ["mutex"] }

--- a/bin/client/src/l1/blob_provider.rs
+++ b/bin/client/src/l1/blob_provider.rs
@@ -5,8 +5,9 @@ use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::Blob;
 use alloy_eips::eip4844::FIELD_ELEMENTS_PER_BLOB;
 use alloy_primitives::keccak256;
+use anyhow::Result;
 use async_trait::async_trait;
-use kona_derive::{errors::BlobProviderError, traits::BlobProvider};
+use kona_derive::traits::BlobProvider;
 use kona_preimage::{CommsClient, PreimageKey, PreimageKeyType};
 use kona_primitives::IndexedBlobHash;
 use op_alloy_protocol::BlockInfo;
@@ -32,11 +33,7 @@ impl<T: CommsClient> OracleBlobProvider<T> {
     /// ## Returns
     /// - `Ok(blob)`: The blob.
     /// - `Err(e)`: The blob could not be retrieved.
-    async fn get_blob(
-        &self,
-        block_ref: &BlockInfo,
-        blob_hash: &IndexedBlobHash,
-    ) -> Result<Blob, BlobProviderError> {
+    async fn get_blob(&self, block_ref: &BlockInfo, blob_hash: &IndexedBlobHash) -> Result<Blob> {
         let mut blob_req_meta = [0u8; 48];
         blob_req_meta[0..32].copy_from_slice(blob_hash.hash.as_ref());
         blob_req_meta[32..40].copy_from_slice((blob_hash.index as u64).to_be_bytes().as_ref());
@@ -76,11 +73,13 @@ impl<T: CommsClient> OracleBlobProvider<T> {
 
 #[async_trait]
 impl<T: CommsClient + Sync + Send> BlobProvider for OracleBlobProvider<T> {
+    type Error = anyhow::Error;
+
     async fn get_blobs(
         &mut self,
         block_ref: &BlockInfo,
         blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<Blob>, BlobProviderError> {
+    ) -> Result<Vec<Blob>, Self::Error> {
         let mut blobs = Vec::with_capacity(blob_hashes.len());
         for hash in blob_hashes {
             blobs.push(self.get_blob(block_ref, hash).await?);

--- a/bin/client/src/l1/chain_provider.rs
+++ b/bin/client/src/l1/chain_provider.rs
@@ -31,6 +31,8 @@ impl<T: CommsClient> OracleL1ChainProvider<T> {
 
 #[async_trait]
 impl<T: CommsClient + Sync + Send> ChainProvider for OracleL1ChainProvider<T> {
+    type Error = anyhow::Error;
+
     async fn header_by_hash(&mut self, hash: B256) -> Result<Header> {
         // Send a hint for the block header.
         self.oracle.write(&HintType::L1BlockHeader.encode_with(&[hash.as_ref()])).await?;

--- a/bin/client/src/l1/driver.rs
+++ b/bin/client/src/l1/driver.rs
@@ -10,7 +10,7 @@ use alloy_consensus::{Header, Sealed};
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use kona_derive::{
-    errors::StageErrorKind,
+    errors::PipelineErrorKind,
     pipeline::{DerivationPipeline, Pipeline, PipelineBuilder, StepResult},
     sources::EthereumDataSource,
     stages::{
@@ -172,11 +172,11 @@ where
                     // complete the current step. In this case, we retry the step to see if other
                     // stages can make progress.
                     match e {
-                        StageErrorKind::Temporary(_) => {}
-                        StageErrorKind::Reset(_) => {
+                        PipelineErrorKind::Temporary(_) => {}
+                        PipelineErrorKind::Reset(_) => {
                             // self.pipeline.reset(l2_block_info, origin);
                         }
-                        StageErrorKind::Critical(_) => return Err(e.into()),
+                        PipelineErrorKind::Critical(_) => return Err(e.into()),
                     }
                 }
             }

--- a/bin/client/src/l1/driver.rs
+++ b/bin/client/src/l1/driver.rs
@@ -10,7 +10,7 @@ use alloy_consensus::{Header, Sealed};
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
 use kona_derive::{
-    errors::StageError,
+    errors::StageErrorKind,
     pipeline::{DerivationPipeline, Pipeline, PipelineBuilder, StepResult},
     sources::EthereumDataSource,
     stages::{
@@ -171,8 +171,12 @@ where
                     // Break the loop unless the error signifies that there is not enough data to
                     // complete the current step. In this case, we retry the step to see if other
                     // stages can make progress.
-                    if !matches!(e, StageError::NotEnoughData | StageError::Temporary(_)) {
-                        break;
+                    match e {
+                        StageErrorKind::Temporary(_) => {}
+                        StageErrorKind::Reset(_) => {
+                            // self.pipeline.reset(l2_block_info, origin);
+                        }
+                        StageErrorKind::Critical(_) => return Err(e.into()),
                     }
                 }
             }

--- a/bin/client/src/l2/chain_provider.rs
+++ b/bin/client/src/l2/chain_provider.rs
@@ -69,12 +69,14 @@ impl<T: CommsClient> OracleL2ChainProvider<T> {
 
 #[async_trait]
 impl<T: CommsClient + Send + Sync> L2ChainProvider for OracleL2ChainProvider<T> {
+    type Error = anyhow::Error;
+
     async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo> {
         // Get the payload at the given block number.
         let payload = self.payload_by_number(number).await?;
 
         // Construct the system config from the payload.
-        payload.to_l2_block_ref(&self.boot_info.rollup_config)
+        payload.to_l2_block_ref(&self.boot_info.rollup_config).map_err(Into::into)
     }
 
     async fn payload_by_number(&mut self, number: u64) -> Result<L2ExecutionPayloadEnvelope> {
@@ -114,7 +116,7 @@ impl<T: CommsClient + Send + Sync> L2ChainProvider for OracleL2ChainProvider<T> 
         let payload = self.payload_by_number(number).await?;
 
         // Construct the system config from the payload.
-        payload.to_system_config(rollup_config.as_ref())
+        payload.to_system_config(rollup_config.as_ref()).map_err(Into::into)
     }
 }
 

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -93,6 +93,7 @@ online = [
 ]
 test-utils = [
   "dep:spin",
+  "dep:anyhow",
   "dep:alloy-transport-http",
   "dep:alloy-node-bindings",
   "dep:tracing-subscriber",

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -26,7 +26,7 @@ unsigned-varint.workspace = true
 miniz_oxide.workspace = true
 brotli.workspace = true
 alloc-no-stdlib.workspace = true
-anyhow.workspace = true
+thiserror.workspace = true
 tracing.workspace = true
 async-trait.workspace = true
 
@@ -55,6 +55,7 @@ alloy-transport-http = { workspace = true, optional = true }
 
 [dev-dependencies]
 spin.workspace = true
+anyhow.workspace = true
 alloy-rpc-client.workspace = true
 alloy-transport-http.workspace = true
 tokio.workspace = true

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -52,6 +52,7 @@ alloy-rpc-client = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 alloy-node-bindings = { workspace = true, optional = true }
 alloy-transport-http = { workspace = true, optional = true } 
+anyhow = { workspace = true, optional = true }
 
 [dev-dependencies]
 spin.workspace = true

--- a/crates/derive/src/batch/mod.rs
+++ b/crates/derive/src/batch/mod.rs
@@ -90,7 +90,7 @@ impl Batch {
 
         match batch_type {
             BatchType::Single => {
-                let single_batch = SingleBatch::decode(r)?;
+                let single_batch = SingleBatch::decode(r).map_err(DecodeError::AlloyRlpError)?;
                 Ok(Batch::Single(single_batch))
             }
             BatchType::Span => {

--- a/crates/derive/src/batch/mod.rs
+++ b/crates/derive/src/batch/mod.rs
@@ -94,8 +94,7 @@ impl Batch {
                 Ok(Batch::Single(single_batch))
             }
             BatchType::Span => {
-                let mut raw_span_batch =
-                    RawSpanBatch::decode(r, cfg).map_err(DecodeError::SpanBatchError)?;
+                let mut raw_span_batch = RawSpanBatch::decode(r, cfg)?;
                 let span_batch = raw_span_batch
                     .derive(cfg.block_time, cfg.genesis.l2_time, cfg.l2_chain_id)
                     .map_err(DecodeError::SpanBatchError)?;

--- a/crates/derive/src/batch/span_batch/bits.rs
+++ b/crates/derive/src/batch/span_batch/bits.rs
@@ -1,9 +1,9 @@
 //! Module for working with span batch bits.
 
+use super::{errors::SpanBatchError, FJORD_MAX_SPAN_BATCH_BYTES, MAX_SPAN_BATCH_BYTES};
 use alloc::{vec, vec::Vec};
 use alloy_rlp::Buf;
 use core::cmp::Ordering;
-use super::{errors::SpanBatchError, FJORD_MAX_SPAN_BATCH_BYTES, MAX_SPAN_BATCH_BYTES};
 
 /// Type for span batch bits.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]

--- a/crates/derive/src/batch/span_batch/bits.rs
+++ b/crates/derive/src/batch/span_batch/bits.rs
@@ -2,9 +2,7 @@
 
 use alloc::{vec, vec::Vec};
 use alloy_rlp::Buf;
-use anyhow::Result;
 use core::cmp::Ordering;
-
 use super::{errors::SpanBatchError, FJORD_MAX_SPAN_BATCH_BYTES, MAX_SPAN_BATCH_BYTES};
 
 /// Type for span batch bits.

--- a/crates/derive/src/batch/span_batch/errors.rs
+++ b/crates/derive/src/batch/span_batch/errors.rs
@@ -1,108 +1,62 @@
 //! Span Batch Errors
 
-use core::fmt::Display;
+use thiserror::Error;
 
 /// Span Batch Errors
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum SpanBatchError {
     /// The span batch is too big
+    #[error("The span batch is too big.")]
     TooBigSpanBatchSize,
     /// The bit field is too long
+    #[error("The bit field is too long")]
     BitfieldTooLong,
-    /// Failed to set [alloy_primitives::U256] from big-endian slice
-    InvalidBitSlice,
     /// Empty Span Batch
+    #[error("Empty span batch")]
     EmptySpanBatch,
     /// Missing L1 origin
+    #[error("Missing L1 origin")]
     MissingL1Origin,
-    /// Encoding errors
-    Encoding(EncodingError),
     /// Decoding errors
-    Decoding(SpanDecodingError),
-}
-
-impl Display for SpanBatchError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            SpanBatchError::TooBigSpanBatchSize => write!(f, "The span batch is too big"),
-            SpanBatchError::BitfieldTooLong => write!(f, "The bit field is too long"),
-            SpanBatchError::InvalidBitSlice => {
-                write!(f, "Failed to set [alloy_primitives::U256] from big-endian slice")
-            }
-            SpanBatchError::EmptySpanBatch => write!(f, "Empty Span Batch"),
-            SpanBatchError::MissingL1Origin => write!(f, "Missing L1 origin"),
-            SpanBatchError::Encoding(e) => write!(f, "Encoding error: {:?}", e),
-            SpanBatchError::Decoding(e) => write!(f, "Decoding error: {:?}", e),
-        }
-    }
-}
-
-/// Encoding Error
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum EncodingError {
-    /// Failed to encode span batch
-    SpanBatch,
-    /// Failed to encode span batch bits
-    SpanBatchBits,
-}
-
-impl Display for EncodingError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            EncodingError::SpanBatch => write!(f, "Failed to encode span batch"),
-            EncodingError::SpanBatchBits => write!(f, "Failed to encode span batch bits"),
-        }
-    }
+    #[error("Span batch decoding error: {0}")]
+    Decoding(#[from] SpanDecodingError),
 }
 
 /// Decoding Error
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
 pub enum SpanDecodingError {
     /// Failed to decode relative timestamp
+    #[error("Failed to decode relative timestamp")]
     RelativeTimestamp,
     /// Failed to decode L1 origin number
+    #[error("Failed to decode L1 origin number")]
     L1OriginNumber,
     /// Failed to decode parent check
+    #[error("Failed to decode parent check")]
     ParentCheck,
     /// Failed to decode L1 origin check
+    #[error("Failed to decode L1 origin check")]
     L1OriginCheck,
     /// Failed to decode block count
+    #[error("Failed to decode block count")]
     BlockCount,
     /// Failed to decode block tx counts
+    #[error("Failed to decode block tx counts")]
     BlockTxCounts,
     /// Failed to decode transaction nonces
+    #[error("Failed to decode transaction nonces")]
     TxNonces,
     /// Mismatch in length between the transaction type and signature arrays in a span batch
     /// transaction payload.
+    #[error("Mismatch in length between the transaction type and signature arrays")]
     TypeSignatureLenMismatch,
     /// Invalid transaction type
+    #[error("Invalid transaction type")]
     InvalidTransactionType,
     /// Invalid transaction data
+    #[error("Invalid transaction data")]
     InvalidTransactionData,
     /// Invalid transaction signature
+    #[error("Invalid transaction signature")]
     InvalidTransactionSignature,
-}
-
-impl Display for SpanDecodingError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            SpanDecodingError::RelativeTimestamp => {
-                write!(f, "Failed to decode relative timestamp")
-            }
-            SpanDecodingError::L1OriginNumber => write!(f, "Failed to decode L1 origin number"),
-            SpanDecodingError::ParentCheck => write!(f, "Failed to decode parent check"),
-            SpanDecodingError::L1OriginCheck => write!(f, "Failed to decode L1 origin check"),
-            SpanDecodingError::BlockCount => write!(f, "Failed to decode block count"),
-            SpanDecodingError::BlockTxCounts => write!(f, "Failed to decode block tx counts"),
-            SpanDecodingError::TxNonces => write!(f, "Failed to decode transaction nonces"),
-            SpanDecodingError::TypeSignatureLenMismatch => {
-                write!(f, "Mismatch in length between the transaction type and signature arrays in a span batch transaction payload")
-            }
-            SpanDecodingError::InvalidTransactionType => write!(f, "Invalid transaction type"),
-            SpanDecodingError::InvalidTransactionData => write!(f, "Invalid transaction data"),
-            SpanDecodingError::InvalidTransactionSignature => {
-                write!(f, "Invalid transaction signature")
-            }
-        }
-    }
 }

--- a/crates/derive/src/errors.rs
+++ b/crates/derive/src/errors.rs
@@ -1,324 +1,186 @@
 //! This module contains derivation errors thrown within the pipeline.
 
 use crate::batch::SpanBatchError;
-use alloc::vec::Vec;
 use alloy_eips::BlockNumHash;
-use alloy_primitives::{Bytes, B256};
-use core::fmt::Display;
+use alloy_primitives::B256;
+use kona_primitives::BlobDecodingError;
 use op_alloy_genesis::system::SystemConfigUpdateError;
-use op_alloy_protocol::Frame;
+use op_alloy_protocol::DepositError;
+use thiserror::Error;
 
 /// A result type for the derivation pipeline stages.
-pub type StageResult<T> = Result<T, StageError>;
+pub type PipelineResult<T> = Result<T, StageErrorKind>;
 
-/// An error that is thrown within the stages of the derivation pipeline.
-#[derive(Debug)]
-pub enum StageError {
-    /// There is no data to read from the channel bank.
-    Eof,
-    /// A temporary error that allows the operation to be retried.
-    Temporary(anyhow::Error),
+/// [ensure] is a short-hand for bubbling up errors in the case of a condition not being met.
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $err:expr) => {
+        if !($cond) {
+            return Err($err);
+        }
+    };
+}
+
+/// A top level filter for [StageError] that sorts by severity.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum StageErrorKind {
+    /// A temporary error.
+    #[error("Temporary error: {0}")]
+    Temporary(#[source] PipelineError),
     /// A critical error.
-    Critical(anyhow::Error),
-    /// There is not enough data progress, but if we wait, the stage will eventually return data
-    /// or produce an EOF error.
+    #[error("Critical error: {0}")]
+    Critical(#[source] PipelineError),
+    /// A reset error.
+    #[error("Pipeline reset: {0}")]
+    Reset(#[from] ResetError),
+}
+
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum PipelineError {
+    /// There is no data to read from the channel bank.
+    #[error("EOF")]
+    Eof,
+    /// There is not enough data to complete the processing of the stage. If the operation is re-tried,
+    /// more data will come in allowing the pipeline to progress, or eventually a [StageErrorNew::Eof]
+    /// will be encountered.
+    #[error("Not enough data")]
     NotEnoughData,
-    /// Failed to fetch block info and transactions by hash.
-    BlockFetch(B256),
-    /// No item returned from the previous stage iterator.
-    Empty,
-    /// No channels are available in the channel bank.
-    NoChannelsAvailable,
-    /// No channel returned by the [crate::stages::ChannelReader] stage.
-    NoChannel,
-    /// Failed to find channel.
+    /// No channels are available in the [ChannelBank].
+    ///
+    /// [ChannelBank]: crate::channel::ChannelBank
+    #[error("The channel bank is empty")]
+    ChannelBankEmpty,
+    /// No channel returned by the [ChannelReader] stage.
+    ///
+    /// [ChannelReader]: crate::stages::ChannelReader
+    #[error("The channel reader has no channel available")]
+    ChannelReaderEmpty,
+    /// Failed to find channel in the [ChannelBank].
+    ///
+    /// [ChannelBank]: crate::channel::ChannelBank
+    #[error("Channel not found in channel bank")]
     ChannelNotFound,
     /// Missing L1 origin.
+    #[error("Missing L1 origin from previous stage")]
     MissingOrigin,
-    /// Failed to build the [OptimismPayloadAttributes] for the next batch.
+    /// Missing data from [L1Retrieval].
+    #[error("L1 Retrieval missing data")]
+    MissingL1Data,
+    /// [SystemConfig] update error.
     ///
-    /// [OptimismPayloadAttributes]: op_alloy_rpc_types_engine::OptimismPayloadAttributes
-    AttributesBuild(BuilderError),
-    /// Reset the pipeline.
-    Reset(ResetError),
-    /// The stage detected a block reorg.
-    /// The first argument is the expected block hash.
-    /// The second argument is the paren_hash of the next l1 origin block.
-    ReorgDetected(B256, B256),
-    /// Receipt fetching error.
-    ReceiptFetch(anyhow::Error),
-    /// [op_alloy_protocol::BlockInfo] fetching error.
-    BlockInfoFetch(anyhow::Error),
-    /// [op_alloy_genesis::SystemConfig] update error.
+    /// [SystemConfig]: op_alloy_genesis::SystemConfig
+    #[error("Error updating system config: {0}")]
     SystemConfigUpdate(SystemConfigUpdateError),
-    /// Other wildcard error.
-    Custom(anyhow::Error),
+    /// Attributes builder error variant, with [BuilderError].
+    #[error("Attributes builder error: {0}")]
+    AttributesBuilder(#[from] BuilderError),
+    /// [DecodeError] variant.
+    #[error("Decode error: {0}")]
+    DecodeError(#[from] DecodeError),
 }
 
-impl PartialEq<StageError> for StageError {
-    fn eq(&self, other: &StageError) -> bool {
-        // if it's a reorg detected check the block hashes
-        if let (StageError::ReorgDetected(a, b), StageError::ReorgDetected(c, d)) = (self, other) {
-            return a == c && b == d;
-        }
-        if let (StageError::Reset(a), StageError::Reset(b)) = (self, other) {
-            return a == b;
-        }
-        matches!(
-            (self, other),
-            (StageError::Eof, StageError::Eof) |
-                (StageError::Temporary(_), StageError::Temporary(_)) |
-                (StageError::Critical(_), StageError::Critical(_)) |
-                (StageError::NotEnoughData, StageError::NotEnoughData) |
-                (StageError::NoChannelsAvailable, StageError::NoChannelsAvailable) |
-                (StageError::NoChannel, StageError::NoChannel) |
-                (StageError::ChannelNotFound, StageError::ChannelNotFound) |
-                (StageError::MissingOrigin, StageError::MissingOrigin) |
-                (StageError::AttributesBuild(_), StageError::AttributesBuild(_)) |
-                (StageError::ReceiptFetch(_), StageError::ReceiptFetch(_)) |
-                (StageError::BlockInfoFetch(_), StageError::BlockInfoFetch(_)) |
-                (StageError::SystemConfigUpdate(_), StageError::SystemConfigUpdate(_)) |
-                (StageError::Custom(_), StageError::Custom(_))
-        )
+impl PipelineError {
+    /// Wrap [self] as a [StageErrorKind::Critical].
+    pub fn crit(self) -> StageErrorKind {
+        StageErrorKind::Critical(self)
     }
-}
 
-/// Converts a stage result into a vector of frames.
-pub fn into_frames<T: Into<Bytes>>(result: StageResult<T>) -> anyhow::Result<Vec<Frame>> {
-    match result {
-        Ok(data) => Ok(Frame::parse_frames(&data.into()).map_err(|e| anyhow::anyhow!(e))?),
-        Err(e) => Err(anyhow::anyhow!(e)),
-    }
-}
-
-impl From<anyhow::Error> for StageError {
-    fn from(e: anyhow::Error) -> Self {
-        StageError::Custom(e)
-    }
-}
-
-impl Display for StageError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            StageError::Eof => write!(f, "End of file"),
-            StageError::Temporary(e) => write!(f, "Temporary error: {}", e),
-            StageError::Critical(e) => write!(f, "Critical error: {}", e),
-            StageError::NotEnoughData => write!(f, "Not enough data"),
-            StageError::BlockFetch(hash) => {
-                write!(f, "Failed to fetch block info and transactions by hash: {}", hash)
-            }
-            StageError::Empty => write!(f, "Empty"),
-            StageError::NoChannelsAvailable => write!(f, "No channels available"),
-            StageError::NoChannel => write!(f, "No channel"),
-            StageError::ChannelNotFound => write!(f, "Channel not found"),
-            StageError::MissingOrigin => write!(f, "Missing L1 origin"),
-            StageError::AttributesBuild(e) => write!(f, "Attributes build error: {}", e),
-            StageError::Reset(e) => write!(f, "Reset error: {}", e),
-            StageError::ReceiptFetch(e) => write!(f, "Receipt fetch error: {}", e),
-            StageError::SystemConfigUpdate(e) => write!(f, "System config update error: {}", e),
-            StageError::ReorgDetected(current, next) => {
-                write!(f, "Block reorg detected: {} -> {}", current, next)
-            }
-            StageError::BlockInfoFetch(e) => write!(f, "Block info fetch error: {}", e),
-            StageError::Custom(e) => write!(f, "Custom error: {}", e),
-        }
-    }
-}
-
-/// An error returned by the [BlobProviderError].
-#[derive(Debug)]
-pub enum BlobProviderError {
-    /// The number of specified blob hashes did not match the number of returned sidecars.
-    SidecarLengthMismatch(usize, usize),
-    /// Slot derivation error.
-    Slot(anyhow::Error),
-    /// A custom [anyhow::Error] occurred.
-    Custom(anyhow::Error),
-}
-
-impl PartialEq for BlobProviderError {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::SidecarLengthMismatch(a, b), Self::SidecarLengthMismatch(c, d)) => {
-                a == c && b == d
-            }
-            (Self::Slot(_), Self::Slot(_)) | (Self::Custom(_), Self::Custom(_)) => true,
-            _ => false,
-        }
-    }
-}
-
-impl Display for BlobProviderError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::SidecarLengthMismatch(a, b) => write!(f, "expected {} sidecars but got {}", a, b),
-            Self::Slot(e) => {
-                write!(f, "Slot Derivation Error: {}", e)
-            }
-            Self::Custom(err) => write!(f, "{}", err),
-        }
-    }
-}
-
-impl From<anyhow::Error> for BlobProviderError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Custom(err)
+    /// Wrap [self] as a [StageErrorKind::Temporary].
+    pub fn temp(self) -> StageErrorKind {
+        StageErrorKind::Temporary(self)
     }
 }
 
 /// A reset error
-#[derive(Debug)]
+#[derive(Error, Debug, Eq, PartialEq)]
 pub enum ResetError {
     /// The batch has a bad parent hash.
     /// The first argument is the expected parent hash, and the second argument is the actual
     /// parent hash.
+    #[error("Bad parent hash: expected {0}, got {1}")]
     BadParentHash(B256, B256),
     /// The batch has a bad timestamp.
     /// The first argument is the expected timestamp, and the second argument is the actual
     /// timestamp.
+    #[error("Bad timestamp: expected {0}, got {1}")]
     BadTimestamp(u64, u64),
-    /// A reorg is required.
-    ReorgRequired,
-    /// A new expired challenge.
-    NewExpiredChallenge,
+    /// The stage detected a block reorg.
+    /// The first argument is the expected block hash.
+    /// The second argument is the parent_hash of the next l1 origin block.
+    #[error("L1 reorg detected: expected {0}, got {1}")]
+    ReorgDetected(B256, B256),
+    /// Attributes builder error variant, with [BuilderError].
+    #[error("Attributes builder error: {0}")]
+    AttributesBuilder(#[from] BuilderError),
 }
 
-impl PartialEq<ResetError> for ResetError {
-    fn eq(&self, other: &ResetError) -> bool {
-        match (self, other) {
-            (ResetError::BadParentHash(e1, a1), ResetError::BadParentHash(e2, a2)) => {
-                e1 == e2 && a1 == a2
-            }
-            (ResetError::BadTimestamp(e1, a1), ResetError::BadTimestamp(e2, a2)) => {
-                e1 == e2 && a1 == a2
-            }
-            (ResetError::ReorgRequired, ResetError::ReorgRequired) => true,
-            (ResetError::NewExpiredChallenge, ResetError::NewExpiredChallenge) => true,
-            _ => false,
-        }
-    }
-}
-
-impl Display for ResetError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            ResetError::BadParentHash(expected, actual) => {
-                write!(f, "Bad parent hash: expected {}, got {}", expected, actual)
-            }
-            ResetError::BadTimestamp(expected, actual) => {
-                write!(f, "Bad timestamp: expected {}, got {}", expected, actual)
-            }
-            ResetError::ReorgRequired => write!(f, "Reorg required"),
-            ResetError::NewExpiredChallenge => write!(f, "New expired challenge"),
-        }
-    }
+/// An error returned by the [BlobProviderError].
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum BlobProviderError {
+    /// The number of specified blob hashes did not match the number of returned sidecars.
+    #[error("Blob sidecar length mismatch: expected {0}, got {1}")]
+    SidecarLengthMismatch(usize, usize),
+    /// Slot derivation error.
+    #[error("Failed to derive slot")]
+    SlotDerivation,
+    /// Blob decoding error.
+    #[error("Blob decoding error: {0}")]
+    BlobDecoding(#[from] BlobDecodingError),
+    /// Error pertaining to the backend transport.
+    #[error("Blob provider backend error: {0}")]
+    Backend(String),
 }
 
 /// A decoding error.
-#[derive(Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum DecodeError {
     /// The buffer is empty.
+    #[error("Empty buffer")]
     EmptyBuffer,
+    /// Deposit decoding error.
+    #[error("Error decoding deposit: {0}")]
+    DepositError(#[from] DepositError),
     /// Alloy RLP Encoding Error.
-    AlloyRlpError(alloy_rlp::Error),
+    #[error(transparent)]
+    AlloyRlpError(#[from] alloy_rlp::Error),
     /// Span Batch Error.
-    SpanBatchError(SpanBatchError),
+    #[error(transparent)]
+    SpanBatchError(#[from] SpanBatchError),
 }
 
-impl From<alloy_rlp::Error> for DecodeError {
-    fn from(e: alloy_rlp::Error) -> Self {
-        DecodeError::AlloyRlpError(e)
-    }
-}
-
-impl PartialEq<DecodeError> for DecodeError {
-    fn eq(&self, other: &DecodeError) -> bool {
-        matches!(
-            (self, other),
-            (DecodeError::EmptyBuffer, DecodeError::EmptyBuffer) |
-                (DecodeError::AlloyRlpError(_), DecodeError::AlloyRlpError(_))
-        )
-    }
-}
-
-impl Display for DecodeError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            DecodeError::EmptyBuffer => write!(f, "Empty buffer"),
-            DecodeError::AlloyRlpError(e) => write!(f, "Alloy RLP Decoding Error: {}", e),
-            DecodeError::SpanBatchError(e) => write!(f, "Span Batch Decoding Error: {:?}", e),
-        }
-    }
+/// A frame decompression error.
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum BatchDecompressionError {
+    /// The buffer exceeds the [FJORD_MAX_SPAN_BATCH_BYTES] protocol parameter.
+    ///
+    /// [FJORD_MAX_SPAN_BATCH_BYTES]: crate::batch::FJORD_MAX_SPAN_BATCH_BYTES
+    #[error("The batch exceeds the maximum size of {max_size} bytes", max_size = crate::batch::FJORD_MAX_SPAN_BATCH_BYTES)]
+    BatchTooLarge,
 }
 
 /// An [AttributesBuilder] Error.
 ///
 /// [AttributesBuilder]: crate::stages::AttributesBuilder
-#[derive(Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum BuilderError {
     /// Mismatched blocks.
+    #[error("Block mismatch. Expected {0:?}, got {1:?}")]
     BlockMismatch(BlockNumHash, BlockNumHash),
     /// Mismatched blocks for the start of an Epoch.
+    #[error("Block mismatch on epoch reset. Expected {0:?}, got {1:?}")]
     BlockMismatchEpochReset(BlockNumHash, BlockNumHash, B256),
     /// [SystemConfig] update failed.
     ///
     /// [SystemConfig]: op_alloy_genesis::SystemConfig
+    #[error("System config update failed")]
     SystemConfigUpdate,
     /// Broken time invariant between L2 and L1.
+    #[error("Time invariant broken. L1 origin: {0:?} | Next L2 time: {1} | L1 block: {2:?} | L1 timestamp {3:?}")]
     BrokenTimeInvariant(BlockNumHash, u64, BlockNumHash, u64),
-    /// A custom error wrapping [anyhow::Error].
-    Custom(anyhow::Error),
-}
-
-impl PartialEq<BuilderError> for BuilderError {
-    fn eq(&self, other: &BuilderError) -> bool {
-        match (self, other) {
-            (BuilderError::BlockMismatch(b1, e1), BuilderError::BlockMismatch(b2, e2)) => {
-                b1 == b2 && e1 == e2
-            }
-            (
-                BuilderError::BlockMismatchEpochReset(b1, e1, e2),
-                BuilderError::BlockMismatchEpochReset(b2, e3, e4),
-            ) => e1 == e3 && e2 == e4 && b1 == b2,
-            (
-                BuilderError::BrokenTimeInvariant(b1, t1, b2, t2),
-                BuilderError::BrokenTimeInvariant(b3, t3, b4, t4),
-            ) => b1 == b3 && t1 == t3 && b2 == b4 && t2 == t4,
-            (BuilderError::SystemConfigUpdate, BuilderError::SystemConfigUpdate) |
-            (BuilderError::Custom(_), BuilderError::Custom(_)) => true,
-            _ => false,
-        }
-    }
-}
-
-impl From<anyhow::Error> for BuilderError {
-    fn from(e: anyhow::Error) -> Self {
-        BuilderError::Custom(e)
-    }
-}
-
-impl Display for BuilderError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            BuilderError::BlockMismatch(block_id, parent) => {
-                write!(f, "Block mismatch with L1 origin {:?} (parent {:?})", block_id, parent)
-            }
-            BuilderError::BlockMismatchEpochReset(block_id, parent, origin) => {
-                write!(
-                    f,
-                    "Block mismatch with L1 origin {:?} (parent {:?}) on top of L1 origin {}",
-                    block_id, parent, origin
-                )
-            }
-            BuilderError::SystemConfigUpdate => write!(f, "System config update failed"),
-            BuilderError::BrokenTimeInvariant(block_id, l2_time, parent, l1_time) => {
-                write!(
-                    f,
-                    "Cannot build L2 block on top {:?} (time {}) before L1 origin {:?} (time {})",
-                    block_id, l2_time, parent, l1_time
-                )
-            }
-            BuilderError::Custom(e) => write!(f, "Custom error: {}", e),
-        }
-    }
+    /// Attributes unavailable.
+    #[error("Attributes unavailable")]
+    AttributesUnavailable,
+    /// A custom error.
+    #[error("Error in attributes builder: {0}")]
+    Custom(String),
 }

--- a/crates/derive/src/errors.rs
+++ b/crates/derive/src/errors.rs
@@ -7,6 +7,7 @@ use kona_primitives::BlobDecodingError;
 use op_alloy_genesis::system::SystemConfigUpdateError;
 use op_alloy_protocol::DepositError;
 use thiserror::Error;
+use alloc::string::String;
 
 /// A result type for the derivation pipeline stages.
 pub type PipelineResult<T> = Result<T, StageErrorKind>;
@@ -35,6 +36,7 @@ pub enum StageErrorKind {
     Reset(#[from] ResetError),
 }
 
+/// An error encountered during the processing.
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum PipelineError {
     /// There is no data to read from the channel bank.
@@ -55,6 +57,11 @@ pub enum PipelineError {
     /// [ChannelReader]: crate::stages::ChannelReader
     #[error("The channel reader has no channel available")]
     ChannelReaderEmpty,
+    /// The [BatchQueue] is empty.
+    ///
+    /// [BatchQueue]: crate::statges::BatchQueue
+    #[error("The batch queue has no batches available")]
+    BatchQueueEmpty,
     /// Failed to find channel in the [ChannelBank].
     ///
     /// [ChannelBank]: crate::channel::ChannelBank
@@ -77,6 +84,12 @@ pub enum PipelineError {
     /// [DecodeError] variant.
     #[error("Decode error: {0}")]
     DecodeError(#[from] DecodeError),
+    /// Provider error variant.
+    #[error("Blob provider error: {0}")]
+    Provider(String),
+    /// Custom error variant.
+    #[error("Pipeline error: {0}")]
+    Custom(String),
 }
 
 impl PipelineError {
@@ -104,6 +117,9 @@ pub enum ResetError {
     /// timestamp.
     #[error("Bad timestamp: expected {0}, got {1}")]
     BadTimestamp(u64, u64),
+    /// L1 origin mismatch.
+    #[error("L1 origin mismatch. Expected {0:?}, got {1:?}")]
+    L1OriginMismatch(u64, u64),
     /// The stage detected a block reorg.
     /// The first argument is the expected block hash.
     /// The second argument is the parent_hash of the next l1 origin block.

--- a/crates/derive/src/errors.rs
+++ b/crates/derive/src/errors.rs
@@ -83,15 +83,12 @@ pub enum PipelineError {
     /// Attributes builder error variant, with [BuilderError].
     #[error("Attributes builder error: {0}")]
     AttributesBuilder(#[from] BuilderError),
-    /// [DecodeError] variant.
+    /// [PipelineEncodingError] variant.
     #[error("Decode error: {0}")]
-    DecodeError(#[from] DecodeError),
+    BadEncoding(#[from] PipelineEncodingError),
     /// Provider error variant.
     #[error("Blob provider error: {0}")]
     Provider(String),
-    /// Custom error variant.
-    #[error("Pipeline error: {0}")]
-    Custom(String),
 }
 
 impl PipelineError {
@@ -132,26 +129,9 @@ pub enum ResetError {
     AttributesBuilder(#[from] BuilderError),
 }
 
-/// An error returned by the [BlobProviderError].
-#[derive(Error, Debug, PartialEq, Eq)]
-pub enum BlobProviderError {
-    /// The number of specified blob hashes did not match the number of returned sidecars.
-    #[error("Blob sidecar length mismatch: expected {0}, got {1}")]
-    SidecarLengthMismatch(usize, usize),
-    /// Slot derivation error.
-    #[error("Failed to derive slot")]
-    SlotDerivation,
-    /// Blob decoding error.
-    #[error("Blob decoding error: {0}")]
-    BlobDecoding(#[from] BlobDecodingError),
-    /// Error pertaining to the backend transport.
-    #[error("{0}")]
-    Backend(String),
-}
-
 /// A decoding error.
 #[derive(Error, Debug, PartialEq, Eq)]
-pub enum DecodeError {
+pub enum PipelineEncodingError {
     /// The buffer is empty.
     #[error("Empty buffer")]
     EmptyBuffer,
@@ -201,4 +181,21 @@ pub enum BuilderError {
     /// A custom error.
     #[error("Error in attributes builder: {0}")]
     Custom(String),
+}
+
+/// An error returned by the [BlobProviderError].
+#[derive(Error, Debug, PartialEq, Eq)]
+pub enum BlobProviderError {
+    /// The number of specified blob hashes did not match the number of returned sidecars.
+    #[error("Blob sidecar length mismatch: expected {0}, got {1}")]
+    SidecarLengthMismatch(usize, usize),
+    /// Slot derivation error.
+    #[error("Failed to derive slot")]
+    SlotDerivation,
+    /// Blob decoding error.
+    #[error("Blob decoding error: {0}")]
+    BlobDecoding(#[from] BlobDecodingError),
+    /// Error pertaining to the backend transport.
+    #[error("{0}")]
+    Backend(String),
 }

--- a/crates/derive/src/errors.rs
+++ b/crates/derive/src/errors.rs
@@ -10,7 +10,7 @@ use op_alloy_protocol::DepositError;
 use thiserror::Error;
 
 /// A result type for the derivation pipeline stages.
-pub type PipelineResult<T> = Result<T, StageErrorKind>;
+pub type PipelineResult<T> = Result<T, PipelineErrorKind>;
 
 /// [crate::ensure] is a short-hand for bubbling up errors in the case of a condition not being met.
 #[macro_export]
@@ -24,7 +24,7 @@ macro_rules! ensure {
 
 /// A top level filter for [PipelineError] that sorts by severity.
 #[derive(Error, Debug, PartialEq, Eq)]
-pub enum StageErrorKind {
+pub enum PipelineErrorKind {
     /// A temporary error.
     #[error("Temporary error: {0}")]
     Temporary(#[source] PipelineError),
@@ -95,14 +95,14 @@ pub enum PipelineError {
 }
 
 impl PipelineError {
-    /// Wrap [self] as a [StageErrorKind::Critical].
-    pub fn crit(self) -> StageErrorKind {
-        StageErrorKind::Critical(self)
+    /// Wrap [self] as a [PipelineErrorKind::Critical].
+    pub fn crit(self) -> PipelineErrorKind {
+        PipelineErrorKind::Critical(self)
     }
 
-    /// Wrap [self] as a [StageErrorKind::Temporary].
-    pub fn temp(self) -> StageErrorKind {
-        StageErrorKind::Temporary(self)
+    /// Wrap [self] as a [PipelineErrorKind::Temporary].
+    pub fn temp(self) -> PipelineErrorKind {
+        PipelineErrorKind::Temporary(self)
     }
 }
 

--- a/crates/derive/src/errors.rs
+++ b/crates/derive/src/errors.rs
@@ -159,8 +159,8 @@ pub enum DecodeError {
     #[error("Error decoding deposit: {0}")]
     DepositError(#[from] DepositError),
     /// Alloy RLP Encoding Error.
-    #[error(transparent)]
-    AlloyRlpError(#[from] alloy_rlp::Error),
+    #[error("RLP error: {0}")]
+    AlloyRlpError(alloy_rlp::Error),
     /// Span Batch Error.
     #[error(transparent)]
     SpanBatchError(#[from] SpanBatchError),

--- a/crates/derive/src/online/alloy_providers.rs
+++ b/crates/derive/src/online/alloy_providers.rs
@@ -305,11 +305,13 @@ impl AlloyL2ChainProvider {
 
     /// Returns the latest L2 block number.
     pub async fn latest_block_number(&mut self) -> Result<u64, RpcError<TransportErrorKind>> {
-        let s =
-            self.inner.raw_request::<(), alloc::string::String>("eth_blockNumber".into(), ()).await?;
+        let s = self
+            .inner
+            .raw_request::<(), alloc::string::String>("eth_blockNumber".into(), ())
+            .await?;
         U64::from_str(s.as_str())
-                .map_err(|e| RpcError::LocalUsageError(Box::new(e)))
-                .map(|u| u.to::<u64>())
+            .map_err(|e| RpcError::LocalUsageError(Box::new(e)))
+            .map(|u| u.to::<u64>())
     }
 
     /// Creates a new [AlloyL2ChainProvider] from the provided [reqwest::Url].

--- a/crates/derive/src/online/alloy_providers.rs
+++ b/crates/derive/src/online/alloy_providers.rs
@@ -354,7 +354,7 @@ impl L2ChainProvider for AlloyL2ChainProvider {
                     PROVIDER_ERRORS,
                     &["l2_chain_provider", "l2_block_info_by_number", "to_l2_block_ref"]
                 );
-                return Err(e);
+                return Err(RpcError::LocalUsageError(Box::new(e)));
             }
         };
         self.l2_block_info_by_number_cache.put(number, l2_block_info);
@@ -438,7 +438,7 @@ impl L2ChainProvider for AlloyL2ChainProvider {
                     PROVIDER_ERRORS,
                     &["l2_chain_provider", "system_config_by_number", "to_system_config"]
                 );
-                return Err(e);
+                return Err(RpcError::LocalUsageError(Box::new(e)));
             }
         };
         self.system_config_by_number_cache.put(number, sys_config);

--- a/crates/derive/src/online/beacon_client.rs
+++ b/crates/derive/src/online/beacon_client.rs
@@ -1,8 +1,13 @@
 //! Contains an online implementation of the [BeaconClient] trait.
 
-use core::fmt::Display;
-use alloc::{boxed::Box, format, string::String, vec::Vec, string::ToString};
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
 use async_trait::async_trait;
+use core::fmt::Display;
 use reqwest::Client;
 
 use kona_primitives::{

--- a/crates/derive/src/online/blob_provider.rs
+++ b/crates/derive/src/online/blob_provider.rs
@@ -113,10 +113,7 @@ impl<B: BeaconClient, S: SlotDerivation> OnlineBlobProvider<B, S> {
 
         // Validate the correct number of blob sidecars were retrieved.
         if blob_hashes.len() != filtered.len() {
-            return Err(BlobProviderError::SidecarLengthMismatch(
-                blob_hashes.len(),
-                filtered.len(),
-            ));
+            return Err(BlobProviderError::SidecarLengthMismatch(blob_hashes.len(), filtered.len()));
         }
 
         Ok(filtered.into_iter().map(|s| s.inner).collect::<Vec<BlobSidecar>>())
@@ -295,10 +292,7 @@ impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
 
         // Validate the correct number of blob sidecars were retrieved.
         if blob_hashes.len() != filtered.len() {
-            return Err(BlobProviderError::SidecarLengthMismatch(
-                blob_hashes.len(),
-                filtered.len(),
-            ));
+            return Err(BlobProviderError::SidecarLengthMismatch(blob_hashes.len(), filtered.len()));
         }
 
         Ok(filtered.into_iter().map(|s| s.inner).collect::<Vec<BlobSidecar>>())

--- a/crates/derive/src/online/blob_provider.rs
+++ b/crates/derive/src/online/blob_provider.rs
@@ -6,7 +6,11 @@ use crate::{
     online::{BeaconClient, OnlineBeaconClient},
     traits::BlobProvider,
 };
-use alloc::{boxed::Box, string::String, vec::Vec};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 use alloy_eips::eip4844::Blob;
 use async_trait::async_trait;
 use core::marker::PhantomData;
@@ -109,10 +113,7 @@ impl<B: BeaconClient, S: SlotDerivation> OnlineBlobProvider<B, S> {
 
         // Validate the correct number of blob sidecars were retrieved.
         if blob_hashes.len() != filtered.len() {
-            return Err(BlobProviderError::SidecarLengthMismatch(
-                blob_hashes.len(),
-                filtered.len(),
-            ));
+            return Err(BlobProviderError::SidecarLengthMismatch(blob_hashes.len(), filtered.len()));
         }
 
         Ok(filtered.into_iter().map(|s| s.inner).collect::<Vec<BlobSidecar>>())
@@ -291,10 +292,7 @@ impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
 
         // Validate the correct number of blob sidecars were retrieved.
         if blob_hashes.len() != filtered.len() {
-            return Err(BlobProviderError::SidecarLengthMismatch(
-                blob_hashes.len(),
-                filtered.len(),
-            ));
+            return Err(BlobProviderError::SidecarLengthMismatch(blob_hashes.len(), filtered.len()));
         }
 
         Ok(filtered.into_iter().map(|s| s.inner).collect::<Vec<BlobSidecar>>())
@@ -565,7 +563,7 @@ mod tests {
         let result = blob_provider.get_blobs(&block_ref, &blob_hashes).await;
         assert_eq!(
             result.unwrap_err(),
-            BlobProviderError::Backend("failed to get beacon genesis".to_string())
+            BlobProviderError::Backend("beacon_genesis not set".to_string())
         );
     }
 
@@ -582,7 +580,7 @@ mod tests {
         let result = blob_provider.get_blobs(&block_ref, &blob_hashes).await;
         assert_eq!(
             result.unwrap_err(),
-            BlobProviderError::Backend("failed to get config spec".to_string())
+            BlobProviderError::Backend("config_spec not set".to_string())
         );
     }
 

--- a/crates/derive/src/online/blob_provider.rs
+++ b/crates/derive/src/online/blob_provider.rs
@@ -1,5 +1,11 @@
 //! Contains an online implementation of the [BlobProvider] trait.
 
+use crate::{
+    ensure,
+    errors::BlobProviderError,
+    online::{BeaconClient, OnlineBeaconClient},
+    traits::BlobProvider,
+};
 use alloc::{boxed::Box, string::String, vec::Vec};
 use alloy_eips::eip4844::Blob;
 use async_trait::async_trait;
@@ -7,10 +13,6 @@ use core::marker::PhantomData;
 use kona_primitives::{APIBlobSidecar, BlobSidecar, IndexedBlobHash};
 use op_alloy_protocol::BlockInfo;
 use tracing::warn;
-
-use crate::{
-    ensure, errors::BlobProviderError, online::{BeaconClient, OnlineBeaconClient}, traits::BlobProvider
-};
 
 /// Specifies the derivation of a slot from a timestamp.
 pub trait SlotDerivation {
@@ -44,11 +46,24 @@ impl<B: BeaconClient, S: SlotDerivation> OnlineBlobProvider<B, S> {
     /// Loads the beacon genesis and config spec
     pub async fn load_configs(&mut self) -> Result<(), BlobProviderError> {
         if self.genesis_time.is_none() {
-            self.genesis_time = Some(self.beacon_client.beacon_genesis().await?.data.genesis_time);
+            self.genesis_time = Some(
+                self.beacon_client
+                    .beacon_genesis()
+                    .await
+                    .map_err(|e| BlobProviderError::Backend(e.to_string()))?
+                    .data
+                    .genesis_time,
+            );
         }
         if self.slot_interval.is_none() {
-            self.slot_interval =
-                Some(self.beacon_client.config_spec().await.map_err(|e| BlobProviderError::Backend(e))?.data.seconds_per_slot);
+            self.slot_interval = Some(
+                self.beacon_client
+                    .config_spec()
+                    .await
+                    .map_err(|e| BlobProviderError::Backend(e.to_string()))?
+                    .data
+                    .seconds_per_slot,
+            );
         }
         Ok(())
     }
@@ -80,8 +95,7 @@ impl<B: BeaconClient, S: SlotDerivation> OnlineBlobProvider<B, S> {
         let interval = self.slot_interval.expect("Config Spec Loaded");
 
         // Calculate the slot for the given timestamp.
-        let slot =
-            S::slot(genesis, interval, block_ref.timestamp)?;
+        let slot = S::slot(genesis, interval, block_ref.timestamp)?;
 
         // Fetch blob sidecars for the slot using the given blob hashes.
         let sidecars = self.fetch_sidecars(slot, blob_hashes).await?;
@@ -95,7 +109,10 @@ impl<B: BeaconClient, S: SlotDerivation> OnlineBlobProvider<B, S> {
 
         // Validate the correct number of blob sidecars were retrieved.
         if blob_hashes.len() != filtered.len() {
-            return Err(BlobProviderError::SidecarLengthMismatch(blob_hashes.len(), filtered.len()));
+            return Err(BlobProviderError::SidecarLengthMismatch(
+                blob_hashes.len(),
+                filtered.len(),
+            ));
         }
 
         Ok(filtered.into_iter().map(|s| s.inner).collect::<Vec<BlobSidecar>>())
@@ -108,10 +125,7 @@ pub struct SimpleSlotDerivation;
 
 impl SlotDerivation for SimpleSlotDerivation {
     fn slot(genesis: u64, slot_time: u64, timestamp: u64) -> Result<u64, BlobProviderError> {
-        ensure!(
-            timestamp >= genesis,
-            BlobProviderError::SlotDerivation 
-        );
+        ensure!(timestamp >= genesis, BlobProviderError::SlotDerivation);
         Ok((timestamp - genesis) / slot_time)
     }
 }
@@ -160,13 +174,15 @@ where
             .into_iter()
             .enumerate()
             .map(|(i, sidecar)| {
-                let hash = blob_hashes.get(i).ok_or(anyhow!("failed to get blob hash"))?;
-                match sidecar.verify_blob(hash) {
-                    Ok(_) => Ok(sidecar.blob),
-                    Err(e) => Err(e),
-                }
+                let hash = blob_hashes
+                    .get(i)
+                    .ok_or(BlobProviderError::Backend("Missing blob hash".to_string()))?;
+                sidecar
+                    .verify_blob(hash)
+                    .map(|_| sidecar.blob)
+                    .map_err(|e| BlobProviderError::Backend(e.to_string()))
             })
-            .collect::<anyhow::Result<Vec<Blob>>>()
+            .collect::<Result<Vec<Blob>, BlobProviderError>>()
         {
             Ok(blobs) => blobs,
             Err(e) => {
@@ -192,7 +208,7 @@ pub trait BlobSidecarProvider {
         &self,
         slot: u64,
         hashes: &[IndexedBlobHash],
-    ) -> anyhow::Result<Vec<APIBlobSidecar>>;
+    ) -> Result<Vec<APIBlobSidecar>, BlobProviderError>;
 }
 
 /// Blanket implementation of the [BlobSidecarProvider] trait for all types that
@@ -203,8 +219,10 @@ impl<B: BeaconClient + Send + Sync> BlobSidecarProvider for B {
         &self,
         slot: u64,
         hashes: &[IndexedBlobHash],
-    ) -> anyhow::Result<Vec<APIBlobSidecar>> {
-        self.beacon_blob_side_cars(slot, hashes).await
+    ) -> Result<Vec<APIBlobSidecar>, BlobProviderError> {
+        self.beacon_blob_side_cars(slot, hashes)
+            .await
+            .map_err(|e| BlobProviderError::Backend(e.to_string()))
     }
 }
 
@@ -245,9 +263,9 @@ impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
         blob_hashes: &[IndexedBlobHash],
     ) -> Result<Vec<BlobSidecar>, BlobProviderError> {
         let Some(fallback) = self.fallback.as_ref() else {
-            return Err(BlobProviderError::Custom(anyhow::anyhow!(
-                "cannot fetch blobs: the primary blob provider failed, and no fallback is configured"
-            )));
+            return Err(BlobProviderError::Backend(
+                "cannot fetch blobs: the primary blob provider failed, and no fallback is configured".to_string()
+            ));
         };
 
         if blob_hashes.is_empty() {
@@ -259,8 +277,7 @@ impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
             self.primary.genesis_time.expect("Genesis Config Loaded"),
             self.primary.slot_interval.expect("Config Spec Loaded"),
             block_ref.timestamp,
-        )
-        .map_err(BlobProviderError::Slot)?;
+        )?;
 
         // Fetch blob sidecars for the given block reference and blob hashes.
         let sidecars = fallback.beacon_blob_side_cars(slot, blob_hashes).await?;
@@ -274,7 +291,10 @@ impl<B: BeaconClient, F: BlobSidecarProvider, S: SlotDerivation>
 
         // Validate the correct number of blob sidecars were retrieved.
         if blob_hashes.len() != filtered.len() {
-            return Err(BlobProviderError::SidecarLengthMismatch(blob_hashes.len(), filtered.len()));
+            return Err(BlobProviderError::SidecarLengthMismatch(
+                blob_hashes.len(),
+                filtered.len(),
+            ));
         }
 
         Ok(filtered.into_iter().map(|s| s.inner).collect::<Vec<BlobSidecar>>())
@@ -288,6 +308,8 @@ where
     F: BlobSidecarProvider + Send + Sync,
     S: SlotDerivation + Send + Sync,
 {
+    type Error = BlobProviderError;
+
     /// Fetches blob sidecars that were confirmed in the specified L1 block with the given indexed
     /// hashes. The blobs are validated for their index and hashes using the specified
     /// [IndexedBlobHash].
@@ -321,15 +343,15 @@ where
                     .into_iter()
                     .enumerate()
                     .map(|(i, sidecar)| {
-                        let hash = blob_hashes
-                            .get(i)
-                            .ok_or(anyhow!("fallback: failed to get blob hash"))?;
+                        let hash = blob_hashes.get(i).ok_or(BlobProviderError::Backend(
+                            "fallback: failed to get blob hash".to_string(),
+                        ))?;
                         match sidecar.verify_blob(hash) {
                             Ok(_) => Ok(sidecar.blob),
-                            Err(e) => Err(e),
+                            Err(e) => Err(BlobProviderError::Backend(e.to_string())),
                         }
                     })
-                    .collect::<anyhow::Result<Vec<Blob>>>()
+                    .collect::<Result<Vec<Blob>, BlobProviderError>>()
                 {
                     Ok(blobs) => blobs,
                     Err(e) => {
@@ -337,7 +359,7 @@ where
                             PROVIDER_ERRORS,
                             &["blob_provider", "get_blobs", "fallback_verify_blob"]
                         );
-                        return Err(BlobProviderError::Custom(e));
+                        return Err(e);
                     }
                 };
 
@@ -543,7 +565,7 @@ mod tests {
         let result = blob_provider.get_blobs(&block_ref, &blob_hashes).await;
         assert_eq!(
             result.unwrap_err(),
-            BlobProviderError::Custom(anyhow::anyhow!("failed to get beacon genesis"))
+            BlobProviderError::Backend("failed to get beacon genesis".to_string())
         );
     }
 
@@ -560,7 +582,7 @@ mod tests {
         let result = blob_provider.get_blobs(&block_ref, &blob_hashes).await;
         assert_eq!(
             result.unwrap_err(),
-            BlobProviderError::Custom(anyhow::anyhow!("failed to get config spec"))
+            BlobProviderError::Backend("failed to get config spec".to_string())
         );
     }
 
@@ -576,12 +598,7 @@ mod tests {
         let block_ref = BlockInfo { timestamp: 5, ..Default::default() };
         let blob_hashes = vec![IndexedBlobHash::default()];
         let result = blob_provider.get_blobs(&block_ref, &blob_hashes).await;
-        assert_eq!(
-            result.unwrap_err(),
-            BlobProviderError::Slot(anyhow::anyhow!(
-                "provided timestamp (5) precedes genesis time (10)"
-            ))
-        );
+        assert_eq!(result.unwrap_err(), BlobProviderError::SlotDerivation);
     }
 
     #[tokio::test]
@@ -598,7 +615,7 @@ mod tests {
         let result = blob_provider.get_blobs(&block_ref, &blob_hashes).await;
         assert_eq!(
             result.unwrap_err(),
-            BlobProviderError::Custom(anyhow::anyhow!("blob_sidecars not set"))
+            BlobProviderError::Backend("blob_sidecars not set".to_string())
         );
     }
 
@@ -658,9 +675,10 @@ mod tests {
         let result = blob_provider.get_blobs(&block_ref, &blob_hashes).await;
         assert_eq!(
             result.unwrap_err(),
-            BlobProviderError::Custom(anyhow::anyhow!(
+            BlobProviderError::Backend(
                 "invalid sidecar ordering, blob hash index 4 does not match sidecar index 0"
-            ))
+                    .to_string()
+            )
         );
     }
 
@@ -682,7 +700,7 @@ mod tests {
             ..Default::default()
         }];
         let result = blob_provider.get_blobs(&block_ref, &blob_hashes).await;
-        assert_eq!(result.unwrap_err(), BlobProviderError::Custom(anyhow::anyhow!("expected hash 0x0101010101010101010101010101010101010101010101010101010101010101 for blob at index 0 but got 0x01b0761f87b081d5cf10757ccc89f12be355c70e2e29df288b65b30710dcbcd1")));
+        assert_eq!(result.unwrap_err(), BlobProviderError::Backend("expected hash 0x0101010101010101010101010101010101010101010101010101010101010101 for blob at index 0 but got 0x01b0761f87b081d5cf10757ccc89f12be355c70e2e29df288b65b30710dcbcd1".to_string()));
     }
 
     #[tokio::test]
@@ -705,7 +723,7 @@ mod tests {
         let result = blob_provider.get_blobs(&block_ref, &blob_hashes).await;
         assert_eq!(
             result.unwrap_err(),
-            BlobProviderError::Custom(anyhow::anyhow!("blob at index 0 failed verification"))
+            BlobProviderError::Backend("blob at index 0 failed verification".to_string())
         );
     }
 

--- a/crates/derive/src/online/test_utils.rs
+++ b/crates/derive/src/online/test_utils.rs
@@ -48,6 +48,8 @@ pub struct MockBeaconClient {
 
 #[async_trait]
 impl BeaconClient for MockBeaconClient {
+    type Error = anyhow::Error;
+
     async fn config_spec(&self) -> Result<APIConfigResponse> {
         self.config_spec.clone().ok_or_else(|| anyhow!("config_spec not set"))
     }

--- a/crates/derive/src/pipeline/core.rs
+++ b/crates/derive/src/pipeline/core.rs
@@ -107,7 +107,7 @@ where
                     trace!(target: "pipeline", "Stages reset with EOF");
                 } else {
                     error!(target: "pipeline", "Stage reset errored: {:?}", err);
-                    return Err(err.into());
+                    return Err(err);
                 }
             }
         }

--- a/crates/derive/src/pipeline/core.rs
+++ b/crates/derive/src/pipeline/core.rs
@@ -99,7 +99,7 @@ where
             .l2_chain_provider
             .system_config_by_number(l2_block_info.number, Arc::clone(&self.rollup_config))
             .await
-            .map_err(|e| PipelineError::Custom(e.to_string()).temp())?;
+            .map_err(|e| PipelineError::Provider(e.to_string()).temp())?;
         match self.attributes.reset(l1_block_info, &system_config).await {
             Ok(()) => trace!(target: "pipeline", "Stages reset"),
             Err(err) => {

--- a/crates/derive/src/pipeline/core.rs
+++ b/crates/derive/src/pipeline/core.rs
@@ -4,7 +4,7 @@ use super::{
     L2ChainProvider, NextAttributes, OriginAdvancer, OriginProvider, Pipeline, PipelineError,
     PipelineResult, ResettableStage, StepResult,
 };
-use crate::errors::StageErrorKind;
+use crate::errors::PipelineErrorKind;
 use alloc::{boxed::Box, collections::VecDeque, string::ToString, sync::Arc};
 use async_trait::async_trait;
 use core::fmt::Debug;
@@ -103,7 +103,7 @@ where
         match self.attributes.reset(l1_block_info, &system_config).await {
             Ok(()) => trace!(target: "pipeline", "Stages reset"),
             Err(err) => {
-                if let StageErrorKind::Temporary(PipelineError::Eof) = err {
+                if let PipelineErrorKind::Temporary(PipelineError::Eof) = err {
                     trace!(target: "pipeline", "Stages reset with EOF");
                 } else {
                     error!(target: "pipeline", "Stage reset errored: {:?}", err);
@@ -134,7 +134,7 @@ where
                 StepResult::PreparedAttributes
             }
             Err(err) => match err {
-                StageErrorKind::Temporary(PipelineError::Eof) => {
+                PipelineErrorKind::Temporary(PipelineError::Eof) => {
                     trace!(target: "pipeline", "Pipeline advancing origin");
                     if let Err(e) = self.attributes.advance_origin().await {
                         return StepResult::OriginAdvanceErr(e);

--- a/crates/derive/src/pipeline/core.rs
+++ b/crates/derive/src/pipeline/core.rs
@@ -1,11 +1,11 @@
 //! Contains the core derivation pipeline.
 
-use crate::errors::StageErrorKind;
 use super::{
     L2ChainProvider, NextAttributes, OriginAdvancer, OriginProvider, Pipeline, PipelineError,
     PipelineResult, ResettableStage, StepResult,
 };
-use alloc::{boxed::Box, collections::VecDeque, sync::Arc, string::ToString};
+use crate::errors::StageErrorKind;
+use alloc::{boxed::Box, collections::VecDeque, string::ToString, sync::Arc};
 use async_trait::async_trait;
 use core::fmt::Debug;
 use op_alloy_genesis::RollupConfig;
@@ -118,12 +118,14 @@ where
     ///
     /// ## Returns
     ///
-    /// A [StageError::Eof] is returned if the pipeline is blocked by waiting for new L1 data.
+    /// A [PipelineError::Eof] is returned if the pipeline is blocked by waiting for new L1 data.
     /// Any other error is critical and the derivation pipeline should be reset.
     /// An error is expected when the underlying source closes.
     ///
     /// When [DerivationPipeline::step] returns [Ok(())], it should be called again, to continue the
     /// derivation process.
+    ///
+    /// [PipelineError]: crate::errors::PipelineError
     async fn step(&mut self, cursor: L2BlockInfo) -> StepResult {
         match self.attributes.next_attributes(cursor).await {
             Ok(a) => {

--- a/crates/derive/src/pipeline/mod.rs
+++ b/crates/derive/src/pipeline/mod.rs
@@ -10,7 +10,7 @@ pub use crate::traits::{
 pub use crate::stages::AttributesBuilder;
 
 /// Re-export error types.
-pub use crate::errors::{StageError, StageResult};
+pub use crate::errors::{PipelineError, PipelineResult};
 
 mod builder;
 pub use builder::PipelineBuilder;

--- a/crates/derive/src/sources/blobs.rs
+++ b/crates/derive/src/sources/blobs.rs
@@ -4,7 +4,7 @@ use crate::{
     errors::{BlobProviderError, PipelineError, PipelineResult},
     traits::{AsyncIterator, BlobProvider, ChainProvider},
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, vec::Vec, format, string::ToString};
 use alloy_consensus::{Transaction, TxEip4844Variant, TxEnvelope, TxType};
 use alloy_primitives::{Address, Bytes, TxKind};
 use async_trait::async_trait;
@@ -184,7 +184,11 @@ where
 
     async fn next(&mut self) -> PipelineResult<Self::Item> {
         if self.load_blobs().await.is_err() {
-            return Err(PipelineError::ProviderError(self.block_ref.hash));
+            return Err(PipelineError::Provider(format!(
+                "Failed to load blobs from stream: {}",
+                self.block_ref.hash
+            ))
+            .temp());
         }
 
         let next_data = match self.next_data() {

--- a/crates/derive/src/sources/blobs.rs
+++ b/crates/derive/src/sources/blobs.rs
@@ -1,18 +1,16 @@
 //! Blob Data Source
 
+use crate::{
+    errors::{BlobProviderError, PipelineError, PipelineResult},
+    traits::{AsyncIterator, BlobProvider, ChainProvider},
+};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_consensus::{Transaction, TxEip4844Variant, TxEnvelope, TxType};
 use alloy_primitives::{Address, Bytes, TxKind};
-use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use kona_primitives::{BlobData, IndexedBlobHash};
 use op_alloy_protocol::BlockInfo;
 use tracing::warn;
-
-use crate::{
-    errors::{StageError, StageResult},
-    traits::{AsyncIterator, BlobProvider, ChainProvider},
-};
 
 /// A data iterator that reads from a blob.
 #[derive(Debug, Clone)]
@@ -122,13 +120,16 @@ where
     }
 
     /// Loads blob data into the source if it is not open.
-    async fn load_blobs(&mut self) -> Result<()> {
+    async fn load_blobs(&mut self) -> Result<(), BlobProviderError> {
         if self.open {
             return Ok(());
         }
 
-        let info =
-            self.chain_provider.block_info_and_transactions_by_hash(self.block_ref.hash).await?;
+        let info = self
+            .chain_provider
+            .block_info_and_transactions_by_hash(self.block_ref.hash)
+            .await
+            .map_err(|e| BlobProviderError::Backend(e.to_string()))?;
 
         let (mut data, blob_hashes) = self.extract_blob_data(info.1);
 
@@ -142,7 +143,7 @@ where
         let blobs =
             self.blob_fetcher.get_blobs(&self.block_ref, &blob_hashes).await.map_err(|e| {
                 warn!(target: "blob-source", "Failed to fetch blobs: {e}");
-                anyhow!("Failed to fetch blobs: {e}")
+                BlobProviderError::Backend(e.to_string())
             })?;
 
         // Fill the blob pointers.
@@ -153,7 +154,7 @@ where
                     blob_index += 1;
                 }
                 Err(e) => {
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
         }
@@ -164,9 +165,9 @@ where
     }
 
     /// Extracts the next data from the source.
-    fn next_data(&mut self) -> Result<BlobData, Result<Bytes, StageError>> {
+    fn next_data(&mut self) -> Result<BlobData, PipelineResult<Bytes>> {
         if self.data.is_empty() {
-            return Err(Err(StageError::Eof));
+            return Err(Err(PipelineError::Eof.temp()));
         }
 
         Ok(self.data.remove(0))
@@ -181,9 +182,9 @@ where
 {
     type Item = Bytes;
 
-    async fn next(&mut self) -> StageResult<Self::Item> {
+    async fn next(&mut self) -> PipelineResult<Self::Item> {
         if self.load_blobs().await.is_err() {
-            return Err(StageError::BlockFetch(self.block_ref.hash));
+            return Err(PipelineError::ProviderError(self.block_ref.hash));
         }
 
         let next_data = match self.next_data() {

--- a/crates/derive/src/sources/blobs.rs
+++ b/crates/derive/src/sources/blobs.rs
@@ -4,7 +4,7 @@ use crate::{
     errors::{BlobProviderError, PipelineError, PipelineResult},
     traits::{AsyncIterator, BlobProvider, ChainProvider},
 };
-use alloc::{boxed::Box, vec::Vec, format, string::ToString};
+use alloc::{boxed::Box, format, string::ToString, vec::Vec};
 use alloy_consensus::{Transaction, TxEip4844Variant, TxEnvelope, TxType};
 use alloy_primitives::{Address, Bytes, TxKind};
 use async_trait::async_trait;

--- a/crates/derive/src/sources/calldata.rs
+++ b/crates/derive/src/sources/calldata.rs
@@ -1,14 +1,14 @@
 //! CallData Source
 
-use alloc::{boxed::Box, collections::VecDeque};
-use alloy_consensus::{Transaction, TxEnvelope};
-use alloy_primitives::{Address, Bytes, TxKind};
-use async_trait::async_trait;
-use op_alloy_protocol::BlockInfo;
 use crate::{
     errors::{PipelineError, PipelineResult},
     traits::{AsyncIterator, ChainProvider},
 };
+use alloc::{boxed::Box, collections::VecDeque, format};
+use alloy_consensus::{Transaction, TxEnvelope};
+use alloy_primitives::{Address, Bytes, TxKind};
+use async_trait::async_trait;
+use op_alloy_protocol::BlockInfo;
 
 /// A data iterator that reads from calldata.
 #[derive(Debug, Clone)]
@@ -90,7 +90,11 @@ impl<CP: ChainProvider + Send> AsyncIterator for CalldataSource<CP> {
 
     async fn next(&mut self) -> PipelineResult<Self::Item> {
         if self.load_calldata().await.is_err() {
-            return Err(PipelineError::BlockFetch(self.block_ref.hash));
+            return Err(PipelineError::Provider(format!(
+                "Failed to load calldata for block {}",
+                self.block_ref.hash
+            ))
+            .temp());
         }
         self.calldata.pop_front().ok_or(PipelineError::Eof.temp())
     }

--- a/crates/derive/src/sources/calldata.rs
+++ b/crates/derive/src/sources/calldata.rs
@@ -3,12 +3,10 @@
 use alloc::{boxed::Box, collections::VecDeque};
 use alloy_consensus::{Transaction, TxEnvelope};
 use alloy_primitives::{Address, Bytes, TxKind};
-use anyhow::Result;
 use async_trait::async_trait;
 use op_alloy_protocol::BlockInfo;
-
 use crate::{
-    errors::{StageError, StageResult},
+    errors::{PipelineError, PipelineResult},
     traits::{AsyncIterator, ChainProvider},
 };
 
@@ -51,7 +49,7 @@ impl<CP: ChainProvider + Send> CalldataSource<CP> {
     }
 
     /// Loads the calldata into the source if it is not open.
-    async fn load_calldata(&mut self) -> Result<()> {
+    async fn load_calldata(&mut self) -> Result<(), CP::Error> {
         if self.open {
             return Ok(());
         }
@@ -90,10 +88,10 @@ impl<CP: ChainProvider + Send> CalldataSource<CP> {
 impl<CP: ChainProvider + Send> AsyncIterator for CalldataSource<CP> {
     type Item = Bytes;
 
-    async fn next(&mut self) -> StageResult<Self::Item> {
+    async fn next(&mut self) -> PipelineResult<Self::Item> {
         if self.load_calldata().await.is_err() {
-            return Err(StageError::BlockFetch(self.block_ref.hash));
+            return Err(PipelineError::BlockFetch(self.block_ref.hash));
         }
-        self.calldata.pop_front().ok_or(StageError::Eof)
+        self.calldata.pop_front().ok_or(PipelineError::Eof.temp())
     }
 }

--- a/crates/derive/src/sources/ethereum.rs
+++ b/crates/derive/src/sources/ethereum.rs
@@ -2,7 +2,9 @@
 //! [DataAvailabilityProvider] trait for the Ethereum protocol.
 
 use crate::{
-    errors::PipelineResult, sources::{BlobSource, CalldataSource, EthereumDataSourceVariant}, traits::{BlobProvider, ChainProvider, DataAvailabilityProvider}
+    errors::PipelineResult,
+    sources::{BlobSource, CalldataSource, EthereumDataSourceVariant},
+    traits::{BlobProvider, ChainProvider, DataAvailabilityProvider},
 };
 use alloc::{boxed::Box, fmt::Debug};
 use alloy_primitives::{Address, Bytes};

--- a/crates/derive/src/sources/ethereum.rs
+++ b/crates/derive/src/sources/ethereum.rs
@@ -2,12 +2,10 @@
 //! [DataAvailabilityProvider] trait for the Ethereum protocol.
 
 use crate::{
-    sources::{BlobSource, CalldataSource, EthereumDataSourceVariant},
-    traits::{BlobProvider, ChainProvider, DataAvailabilityProvider},
+    errors::PipelineResult, sources::{BlobSource, CalldataSource, EthereumDataSourceVariant}, traits::{BlobProvider, ChainProvider, DataAvailabilityProvider}
 };
 use alloc::{boxed::Box, fmt::Debug};
 use alloy_primitives::{Address, Bytes};
-use anyhow::Result;
 use async_trait::async_trait;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::BlockInfo;
@@ -62,7 +60,7 @@ where
     type Item = Bytes;
     type DataIter = EthereumDataSourceVariant<C, B>;
 
-    async fn open_data(&self, block_ref: &BlockInfo) -> Result<Self::DataIter> {
+    async fn open_data(&self, block_ref: &BlockInfo) -> PipelineResult<Self::DataIter> {
         let ecotone_enabled =
             self.ecotone_timestamp.map(|e| block_ref.timestamp >= e).unwrap_or(false);
         if ecotone_enabled {

--- a/crates/derive/src/sources/variant.rs
+++ b/crates/derive/src/sources/variant.rs
@@ -5,7 +5,7 @@ use alloy_primitives::Bytes;
 use async_trait::async_trait;
 
 use crate::{
-    errors::StageResult,
+    errors::PipelineResult,
     sources::{BlobSource, CalldataSource},
     traits::{AsyncIterator, BlobProvider, ChainProvider},
 };
@@ -31,7 +31,7 @@ where
 {
     type Item = Bytes;
 
-    async fn next(&mut self) -> StageResult<Self::Item> {
+    async fn next(&mut self) -> PipelineResult<Self::Item> {
         match self {
             EthereumDataSourceVariant::Calldata(c) => c.next().await,
             EthereumDataSourceVariant::Blob(b) => b.next().await,

--- a/crates/derive/src/stages/attributes_queue.rs
+++ b/crates/derive/src/stages/attributes_queue.rs
@@ -217,7 +217,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        errors::{BuilderError, StageErrorKind},
+        errors::{BuilderError, PipelineErrorKind},
         stages::test_utils::{
             new_attributes_provider, MockAttributesBuilder, MockAttributesProvider,
         },
@@ -281,7 +281,7 @@ mod tests {
         let result = attributes_queue.create_next_attributes(batch, parent).await.unwrap_err();
         assert_eq!(
             result,
-            StageErrorKind::Reset(ResetError::BadParentHash(Default::default(), bad_hash))
+            PipelineErrorKind::Reset(ResetError::BadParentHash(Default::default(), bad_hash))
         );
     }
 
@@ -291,7 +291,7 @@ mod tests {
         let parent = L2BlockInfo::default();
         let batch = SingleBatch { timestamp: 1, ..Default::default() };
         let result = attributes_queue.create_next_attributes(batch, parent).await.unwrap_err();
-        assert_eq!(result, StageErrorKind::Reset(ResetError::BadTimestamp(1, 0)));
+        assert_eq!(result, PipelineErrorKind::Reset(ResetError::BadTimestamp(1, 0)));
     }
 
     #[tokio::test]
@@ -303,7 +303,7 @@ mod tests {
         };
         let batch = SingleBatch { timestamp: 1, ..Default::default() };
         let result = attributes_queue.create_next_attributes(batch, parent).await.unwrap_err();
-        assert_eq!(result, StageErrorKind::Reset(ResetError::BadTimestamp(1, 2)));
+        assert_eq!(result, PipelineErrorKind::Reset(ResetError::BadTimestamp(1, 2)));
     }
 
     #[tokio::test]
@@ -316,7 +316,7 @@ mod tests {
         };
         let batch = SingleBatch { timestamp: 1, ..Default::default() };
         let result = attributes_queue.create_next_attributes(batch, parent).await.unwrap_err();
-        assert_eq!(result, StageErrorKind::Reset(ResetError::BadTimestamp(1, 2)));
+        assert_eq!(result, PipelineErrorKind::Reset(ResetError::BadTimestamp(1, 2)));
     }
 
     #[tokio::test]

--- a/crates/derive/src/stages/attributes_queue/builder.rs
+++ b/crates/derive/src/stages/attributes_queue/builder.rs
@@ -79,7 +79,7 @@ where
             .config_fetcher
             .system_config_by_number(l2_parent.block_info.number, self.rollup_cfg.clone())
             .await
-            .map_err(|e| PipelineError::Custom(e.to_string()).temp())?;
+            .map_err(|e| PipelineError::Provider(e.to_string()).temp())?;
 
         // If the L1 origin changed in this block, then we are in the first block of the epoch.
         // In this case we need to fetch all transaction receipts from the L1 origin block so
@@ -89,7 +89,7 @@ where
                 .receipts_fetcher
                 .header_by_hash(epoch.hash)
                 .await
-                .map_err(|e| PipelineError::Custom(e.to_string()).temp())?;
+                .map_err(|e| PipelineError::Provider(e.to_string()).temp())?;
             if l2_parent.l1_origin.hash != header.parent_hash {
                 return Err(PipelineErrorKind::Reset(
                     BuilderError::BlockMismatchEpochReset(
@@ -104,11 +104,11 @@ where
                 .receipts_fetcher
                 .receipts_by_hash(epoch.hash)
                 .await
-                .map_err(|e| PipelineError::Custom(e.to_string()).temp())?;
+                .map_err(|e| PipelineError::Provider(e.to_string()).temp())?;
             let deposits =
                 derive_deposits(epoch.hash, &receipts, self.rollup_cfg.deposit_contract_address)
                     .await
-                    .map_err(|e| PipelineError::DecodeError(e).crit())?;
+                    .map_err(|e| PipelineError::BadEncoding(e).crit())?;
             sys_config
                 .update_with_receipts(&receipts, &self.rollup_cfg, header.timestamp)
                 .map_err(|e| PipelineError::SystemConfigUpdate(e).crit())?;
@@ -127,7 +127,7 @@ where
                 .receipts_fetcher
                 .header_by_hash(epoch.hash)
                 .await
-                .map_err(|e| PipelineError::Custom(e.to_string()).temp())?;
+                .map_err(|e| PipelineError::Provider(e.to_string()).temp())?;
             l1_header = header;
             deposit_transactions = vec![];
             l2_parent.seq_num + 1

--- a/crates/derive/src/stages/attributes_queue/builder.rs
+++ b/crates/derive/src/stages/attributes_queue/builder.rs
@@ -6,7 +6,7 @@ use crate::{
     params::SEQUENCER_FEE_VAULT_ADDRESS,
     traits::{ChainProvider, L2ChainProvider},
 };
-use alloc::{boxed::Box, fmt::Debug, sync::Arc, vec, vec::Vec, string::ToString};
+use alloc::{boxed::Box, fmt::Debug, string::ToString, sync::Arc, vec, vec::Vec};
 use alloy_eips::{eip2718::Encodable2718, BlockNumHash};
 use alloy_primitives::Bytes;
 use alloy_rlp::Encodable;
@@ -149,13 +149,13 @@ where
         }
 
         let mut upgrade_transactions: Vec<Bytes> = vec![];
-        if self.rollup_cfg.is_ecotone_active(next_l2_time)
-            && !self.rollup_cfg.is_ecotone_active(l2_parent.block_info.timestamp)
+        if self.rollup_cfg.is_ecotone_active(next_l2_time) &&
+            !self.rollup_cfg.is_ecotone_active(l2_parent.block_info.timestamp)
         {
             upgrade_transactions = Hardforks::ecotone_txs();
         }
-        if self.rollup_cfg.is_fjord_active(next_l2_time)
-            && !self.rollup_cfg.is_fjord_active(l2_parent.block_info.timestamp)
+        if self.rollup_cfg.is_fjord_active(next_l2_time) &&
+            !self.rollup_cfg.is_fjord_active(l2_parent.block_info.timestamp)
         {
             upgrade_transactions.append(&mut Hardforks::fjord_txs());
         }
@@ -212,7 +212,8 @@ where
 mod tests {
     use super::*;
     use crate::{
-        errors::ResetError, stages::test_utils::MockSystemConfigL2Fetcher, traits::test_utils::TestChainProvider
+        errors::ResetError, stages::test_utils::MockSystemConfigL2Fetcher,
+        traits::test_utils::TestChainProvider,
     };
     use alloy_consensus::Header;
     use alloy_primitives::B256;

--- a/crates/derive/src/stages/attributes_queue/builder.rs
+++ b/crates/derive/src/stages/attributes_queue/builder.rs
@@ -6,7 +6,7 @@ use crate::{
     params::SEQUENCER_FEE_VAULT_ADDRESS,
     traits::{ChainProvider, L2ChainProvider},
 };
-use alloc::{boxed::Box, fmt::Debug, sync::Arc, vec, vec::Vec};
+use alloc::{boxed::Box, fmt::Debug, sync::Arc, vec, vec::Vec, string::ToString};
 use alloy_eips::{eip2718::Encodable2718, BlockNumHash};
 use alloy_primitives::Bytes;
 use alloy_rlp::Encodable;
@@ -14,7 +14,7 @@ use alloy_rpc_types_engine::PayloadAttributes;
 use async_trait::async_trait;
 use op_alloy_consensus::Hardforks;
 use op_alloy_genesis::RollupConfig;
-use op_alloy_protocol::{block_info::DecodeError, L1BlockInfoTx, L2BlockInfo};
+use op_alloy_protocol::{L1BlockInfoTx, L2BlockInfo};
 use op_alloy_rpc_types_engine::OptimismPayloadAttributes;
 
 /// The [AttributesBuilder] is responsible for preparing [OptimismPayloadAttributes]
@@ -75,18 +75,21 @@ where
         let l1_header;
         let deposit_transactions: Vec<Bytes>;
 
-        // TODO: Temp RPC error
         let mut sys_config = self
             .config_fetcher
             .system_config_by_number(l2_parent.block_info.number, self.rollup_cfg.clone())
-            .await?;
+            .await
+            .map_err(|e| PipelineError::Custom(e.to_string()).temp())?;
 
         // If the L1 origin changed in this block, then we are in the first block of the epoch.
         // In this case we need to fetch all transaction receipts from the L1 origin block so
         // we can scan for user deposits.
         let sequence_number = if l2_parent.l1_origin.number != epoch.number {
-            // TODO: Temp RPC error
-            let header = self.receipts_fetcher.header_by_hash(epoch.hash).await?;
+            let header = self
+                .receipts_fetcher
+                .header_by_hash(epoch.hash)
+                .await
+                .map_err(|e| PipelineError::Custom(e.to_string()).temp())?;
             if l2_parent.l1_origin.hash != header.parent_hash {
                 return Err(StageErrorKind::Reset(
                     BuilderError::BlockMismatchEpochReset(
@@ -97,10 +100,13 @@ where
                     .into(),
                 ));
             }
-            // TODO: Temp RPC error
-            let receipts = self.receipts_fetcher.receipts_by_hash(epoch.hash).await?;
+            let receipts = self
+                .receipts_fetcher
+                .receipts_by_hash(epoch.hash)
+                .await
+                .map_err(|e| PipelineError::Custom(e.to_string()).temp())?;
             let deposits =
-                derive_deposits(epoch.hash, receipts, self.rollup_cfg.deposit_contract_address)
+                derive_deposits(epoch.hash, &receipts, self.rollup_cfg.deposit_contract_address)
                     .await
                     .map_err(|e| PipelineError::DecodeError(e).crit())?;
             sys_config
@@ -117,8 +123,11 @@ where
                 ));
             }
 
-            // TODO: Temp RPC error
-            let header = self.receipts_fetcher.header_by_hash(epoch.hash).await?;
+            let header = self
+                .receipts_fetcher
+                .header_by_hash(epoch.hash)
+                .await
+                .map_err(|e| PipelineError::Custom(e.to_string()).temp())?;
             l1_header = header;
             deposit_transactions = vec![];
             l2_parent.seq_num + 1
@@ -128,12 +137,15 @@ where
         // between L1 and L2.
         let next_l2_time = l2_parent.block_info.timestamp + self.rollup_cfg.block_time;
         if next_l2_time < l1_header.timestamp {
-            return Err(StageErrorKind::Reset(BuilderError::BrokenTimeInvariant(
-                l2_parent.l1_origin,
-                next_l2_time,
-                BlockNumHash { hash: l1_header.hash_slow(), number: l1_header.number },
-                l1_header.timestamp,
-            ).into()));
+            return Err(StageErrorKind::Reset(
+                BuilderError::BrokenTimeInvariant(
+                    l2_parent.l1_origin,
+                    next_l2_time,
+                    BlockNumHash { hash: l1_header.hash_slow(), number: l1_header.number },
+                    l1_header.timestamp,
+                )
+                .into(),
+            ));
         }
 
         let mut upgrade_transactions: Vec<Bytes> = vec![];
@@ -156,7 +168,9 @@ where
             &l1_header,
             next_l2_time,
         )
-        .map_err(|e| BuilderError::Custom(anyhow::anyhow!(e)))?;
+        .map_err(|e| {
+            PipelineError::AttributesBuilder(BuilderError::Custom(e.to_string())).crit()
+        })?;
         let mut encoded_l1_info_tx = Vec::with_capacity(l1_info_tx_envelope.length());
         l1_info_tx_envelope.encode_2718(&mut encoded_l1_info_tx);
 
@@ -198,7 +212,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        stages::test_utils::MockSystemConfigL2Fetcher, traits::test_utils::TestChainProvider,
+        errors::ResetError, stages::test_utils::MockSystemConfigL2Fetcher, traits::test_utils::TestChainProvider
     };
     use alloy_consensus::Header;
     use alloy_primitives::B256;
@@ -227,7 +241,7 @@ mod tests {
         let expected =
             BuilderError::BlockMismatchEpochReset(epoch, l2_parent.l1_origin, B256::default());
         let err = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap_err();
-        assert_eq!(err, expected);
+        assert_eq!(err, StageErrorKind::Reset(expected.into()));
     }
 
     #[tokio::test]
@@ -251,7 +265,7 @@ mod tests {
         // Here the default header is used whose hash will not equal the custom `l2_hash` above.
         let expected = BuilderError::BlockMismatch(epoch, l2_parent.l1_origin);
         let err = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap_err();
-        assert_eq!(err, expected);
+        assert_eq!(err, StageErrorKind::Reset(ResetError::AttributesBuilder(expected)));
     }
 
     #[tokio::test]
@@ -282,7 +296,7 @@ mod tests {
             timestamp,
         );
         let err = builder.prepare_payload_attributes(l2_parent, epoch).await.unwrap_err();
-        assert_eq!(err, expected);
+        assert_eq!(err, StageErrorKind::Reset(ResetError::AttributesBuilder(expected)));
     }
 
     #[tokio::test]

--- a/crates/derive/src/stages/attributes_queue/deposits.rs
+++ b/crates/derive/src/stages/attributes_queue/deposits.rs
@@ -13,7 +13,7 @@ use crate::errors::DecodeError;
 /// must be the [DEPOSIT_EVENT_ABI_HASH].
 pub(crate) async fn derive_deposits(
     block_hash: B256,
-    receipts: Vec<Receipt>,
+    receipts: &[Receipt],
     deposit_contract: Address,
 ) -> Result<Vec<Bytes>, DecodeError> {
     let mut global_index = 0;
@@ -100,7 +100,7 @@ mod tests {
     async fn test_derive_deposits_empty() {
         let receipts = vec![];
         let deposit_contract = Address::default();
-        let result = derive_deposits(B256::default(), receipts, deposit_contract).await;
+        let result = derive_deposits(B256::default(), &receipts, deposit_contract).await;
         assert!(result.unwrap().is_empty());
     }
 
@@ -110,7 +110,7 @@ mod tests {
         let mut invalid = generate_valid_receipt();
         invalid.logs[0].data = LogData::new_unchecked(vec![], Bytes::default());
         let receipts = vec![generate_valid_receipt(), generate_valid_receipt(), invalid];
-        let result = derive_deposits(B256::default(), receipts, deposit_contract).await;
+        let result = derive_deposits(B256::default(), &receipts, deposit_contract).await;
         assert_eq!(result.unwrap().len(), 5);
     }
 
@@ -120,7 +120,7 @@ mod tests {
         let mut invalid = generate_valid_receipt();
         invalid.logs[0].address = Address::default();
         let receipts = vec![generate_valid_receipt(), generate_valid_receipt(), invalid];
-        let result = derive_deposits(B256::default(), receipts, deposit_contract).await;
+        let result = derive_deposits(B256::default(), &receipts, deposit_contract).await;
         assert_eq!(result.unwrap().len(), 5);
     }
 
@@ -131,7 +131,7 @@ mod tests {
         invalid.logs[0].data =
             LogData::new_unchecked(vec![DEPOSIT_EVENT_ABI_HASH], Bytes::default());
         let receipts = vec![generate_valid_receipt(), generate_valid_receipt(), invalid];
-        let result = derive_deposits(B256::default(), receipts, deposit_contract).await;
+        let result = derive_deposits(B256::default(), &receipts, deposit_contract).await;
         let downcasted = result.unwrap_err();
         assert_eq!(downcasted, DepositError::UnexpectedTopicsLen(1).into());
     }
@@ -140,7 +140,7 @@ mod tests {
     async fn test_derive_deposits_succeeds() {
         let deposit_contract = address!("1111111111111111111111111111111111111111");
         let receipts = vec![generate_valid_receipt(), generate_valid_receipt()];
-        let result = derive_deposits(B256::default(), receipts, deposit_contract).await;
+        let result = derive_deposits(B256::default(), &receipts, deposit_contract).await;
         assert_eq!(result.unwrap().len(), 4);
     }
 }

--- a/crates/derive/src/stages/attributes_queue/deposits.rs
+++ b/crates/derive/src/stages/attributes_queue/deposits.rs
@@ -1,10 +1,10 @@
 //! Contains a helper method to derive deposit transactions from L1 Receipts.
 
+use crate::errors::DecodeError;
 use alloc::vec::Vec;
 use alloy_consensus::{Eip658Value, Receipt};
 use alloy_primitives::{Address, Bytes, B256};
 use op_alloy_protocol::{decode_deposit, DEPOSIT_EVENT_ABI_HASH};
-use crate::errors::DecodeError;
 
 /// Derive deposits for transaction receipts.
 ///
@@ -31,8 +31,7 @@ pub(crate) async fn derive_deposits(
             if l.address != deposit_contract {
                 continue;
             }
-            let decoded =
-                decode_deposit(block_hash, curr_index, l)?;
+            let decoded = decode_deposit(block_hash, curr_index, l)?;
             res.push(decoded);
         }
     }

--- a/crates/derive/src/stages/attributes_queue/deposits.rs
+++ b/crates/derive/src/stages/attributes_queue/deposits.rs
@@ -1,6 +1,6 @@
 //! Contains a helper method to derive deposit transactions from L1 Receipts.
 
-use crate::errors::DecodeError;
+use crate::errors::PipelineEncodingError;
 use alloc::vec::Vec;
 use alloy_consensus::{Eip658Value, Receipt};
 use alloy_primitives::{Address, Bytes, B256};
@@ -15,7 +15,7 @@ pub(crate) async fn derive_deposits(
     block_hash: B256,
     receipts: &[Receipt],
     deposit_contract: Address,
-) -> Result<Vec<Bytes>, DecodeError> {
+) -> Result<Vec<Bytes>, PipelineEncodingError> {
     let mut global_index = 0;
     let mut res = Vec::new();
     for r in receipts.iter() {

--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     batch::{Batch, BatchValidity, BatchWithInclusionBlock, SingleBatch},
-    errors::{DecodeError, PipelineError, PipelineResult, ResetError, StageErrorKind},
+    errors::{DecodeError, PipelineError, PipelineErrorKind, PipelineResult, ResetError},
     stages::attributes_queue::AttributesProvider,
     traits::{L2ChainProvider, OriginAdvancer, OriginProvider, ResettableStage},
 };
@@ -121,7 +121,7 @@ where
         // This is in the case where we auto generate all batches in an epoch & advance the epoch
         // but don't advance the L2 Safe Head's epoch
         if parent.l1_origin != epoch.id() && parent.l1_origin.number != epoch.number - 1 {
-            return Err(StageErrorKind::Reset(ResetError::L1OriginMismatch(
+            return Err(PipelineErrorKind::Reset(ResetError::L1OriginMismatch(
                 parent.l1_origin.number,
                 epoch.number - 1,
             )));
@@ -337,7 +337,7 @@ where
                 }
             }
             Err(e) => {
-                if let StageErrorKind::Temporary(PipelineError::Eof) = e {
+                if let PipelineErrorKind::Temporary(PipelineError::Eof) = e {
                     out_of_data = true;
                 } else {
                     crate::timer!(DISCARD, timer);
@@ -362,7 +362,7 @@ where
             Err(e) => {
                 crate::timer!(DISCARD, timer);
                 match e {
-                    StageErrorKind::Temporary(PipelineError::Eof) => {
+                    PipelineErrorKind::Temporary(PipelineError::Eof) => {
                         if out_of_data {
                             return Err(PipelineError::Eof.temp());
                         }

--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -19,7 +19,7 @@ pub trait BatchQueueProvider {
     /// Returns the next [Batch] in the [ChannelReader] stage, if the stage is not complete.
     /// This function can only be called once while the stage is in progress, and will return
     /// [`None`] on subsequent calls unless the stage is reset or complete. If the stage is
-    /// complete and the batch has been consumed, an [StageError::Eof] error is returned.
+    /// complete and the batch has been consumed, an [PipelineError::Eof] error is returned.
     ///
     /// [ChannelReader]: crate::stages::ChannelReader
     async fn next_batch(&mut self) -> PipelineResult<Batch>;
@@ -102,7 +102,7 @@ where
     /// Derives the next batch to apply on top of the current L2 safe head.
     /// Follows the validity rules imposed on consecutive batches.
     /// Based on currently available buffered batch and L1 origin information.
-    /// A [StageError::Eof] is returned if no batch can be derived yet.
+    /// A [PipelineError::Eof] is returned if no batch can be derived yet.
     pub async fn derive_next_batch(
         &mut self,
         empty: bool,

--- a/crates/derive/src/stages/channel_bank.rs
+++ b/crates/derive/src/stages/channel_bank.rs
@@ -1,7 +1,7 @@
 //! This module contains the `ChannelBank` struct.
 
 use crate::{
-    errors::{PipelineError, PipelineResult, StageErrorKind},
+    errors::{PipelineError, PipelineErrorKind, PipelineResult},
     params::MAX_CHANNEL_BANK_SIZE,
     stages::ChannelReaderProvider,
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
@@ -160,7 +160,7 @@ where
         // At this point we have removed all timed out channels from the front of the
         // `channel_queue`. Pre-Canyon we simply check the first index.
         // Post-Canyon we read the entire channelQueue for the first ready channel.
-        // If no channel is available, we return StageError::Eof.
+        // If no channel is available, we return `PipelineError::Eof`.
         // Canyon is activated when the first L1 block whose time >= CanyonTime, not on the L2
         // timestamp.
         if !self.cfg.is_canyon_active(origin.timestamp) {
@@ -217,7 +217,7 @@ where
         crate::timer!(START, STAGE_ADVANCE_RESPONSE_TIME, &["channel_bank"], timer);
         match self.read() {
             Err(e) => {
-                if !matches!(e, StageErrorKind::Temporary(PipelineError::Eof)) {
+                if !matches!(e, PipelineErrorKind::Temporary(PipelineError::Eof)) {
                     crate::timer!(DISCARD, timer);
                     return Err(PipelineError::ChannelBankEmpty.crit());
                 }

--- a/crates/derive/src/stages/channel_bank.rs
+++ b/crates/derive/src/stages/channel_bank.rs
@@ -1,14 +1,13 @@
 //! This module contains the `ChannelBank` struct.
 
 use crate::{
-    errors::{StageError, StageResult},
+    errors::{PipelineError, PipelineResult, StageErrorKind},
     params::MAX_CHANNEL_BANK_SIZE,
     stages::ChannelReaderProvider,
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
 };
 use alloc::{boxed::Box, collections::VecDeque, sync::Arc};
 use alloy_primitives::{hex, Bytes};
-use anyhow::anyhow;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use hashbrown::HashMap;
@@ -22,7 +21,7 @@ pub trait ChannelBankProvider {
     /// Retrieves the next [Frame] from the [FrameQueue] stage.
     ///
     /// [FrameQueue]: crate::stages::FrameQueue
-    async fn next_frame(&mut self) -> StageResult<Frame>;
+    async fn next_frame(&mut self) -> PipelineResult<Frame>;
 }
 
 /// [ChannelBank] is a stateful stage that does the following:
@@ -68,19 +67,20 @@ where
 
     /// Prunes the Channel bank, until it is below [MAX_CHANNEL_BANK_SIZE].
     /// Prunes from the high-priority channel since it failed to be read.
-    pub fn prune(&mut self) -> StageResult<()> {
+    pub fn prune(&mut self) -> PipelineResult<()> {
         let mut total_size = self.size();
         while total_size > MAX_CHANNEL_BANK_SIZE {
-            let id = self.channel_queue.pop_front().ok_or(StageError::NoChannelsAvailable)?;
-            let channel = self.channels.remove(&id).ok_or(StageError::ChannelNotFound)?;
+            let id =
+                self.channel_queue.pop_front().ok_or(PipelineError::ChannelBankEmpty.crit())?;
+            let channel = self.channels.remove(&id).ok_or(PipelineError::ChannelNotFound.crit())?;
             total_size -= channel.size();
         }
         Ok(())
     }
 
     /// Adds new L1 data to the channel bank. Should only be called after all data has been read.
-    pub fn ingest_frame(&mut self, frame: Frame) -> StageResult<()> {
-        let origin = self.origin().ok_or(StageError::MissingOrigin)?;
+    pub fn ingest_frame(&mut self, frame: Frame) -> PipelineResult<()> {
+        let origin = self.origin().ok_or(PipelineError::MissingOrigin.crit())?;
 
         // Get the channel for the frame, or create a new one if it doesn't exist.
         let current_channel = self.channels.entry(frame.id).or_insert_with(|| {
@@ -90,8 +90,8 @@ where
         });
 
         // Check if the channel is not timed out. If it has, ignore the frame.
-        if current_channel.open_block_number() + self.cfg.channel_timeout(origin.timestamp) <
-            origin.number
+        if current_channel.open_block_number() + self.cfg.channel_timeout(origin.timestamp)
+            < origin.number
         {
             warn!(
                 target: "channel-bank",
@@ -125,18 +125,18 @@ where
     /// Read the raw data of the first channel, if it's timed-out or closed.
     ///
     /// Returns an error if there is nothing new to read.
-    pub fn read(&mut self) -> StageResult<Option<Bytes>> {
+    pub fn read(&mut self) -> PipelineResult<Option<Bytes>> {
         // Bail if there are no channels to read from.
         if self.channel_queue.is_empty() {
             trace!(target: "channel-bank", "No channels to read from");
-            return Err(StageError::Eof);
+            return Err(PipelineError::Eof.temp());
         }
 
         // Return an `Ok(None)` if the first channel is timed out. There may be more timed
         // out channels at the head of the queue and we want to remove them all.
         let first = self.channel_queue[0];
-        let channel = self.channels.get(&first).ok_or(StageError::ChannelNotFound)?;
-        let origin = self.origin().ok_or(StageError::MissingOrigin)?;
+        let channel = self.channels.get(&first).ok_or(PipelineError::ChannelBankEmpty.crit())?;
+        let origin = self.origin().ok_or(PipelineError::ChannelBankEmpty.crit())?;
         if channel.open_block_number() + self.cfg.channel_timeout(origin.timestamp) < origin.number
         {
             warn!(
@@ -171,29 +171,30 @@ where
             (0..self.channel_queue.len()).find_map(|i| self.try_read_channel_at_index(i).ok());
         match channel_data {
             Some(data) => Ok(Some(data)),
-            None => Err(StageError::Eof),
+            None => Err(PipelineError::Eof.temp()),
         }
     }
 
     /// Attempts to read the channel at the specified index. If the channel is not ready or timed
     /// out, it will return an error.
     /// If the channel read was successful, it will remove the channel from the channel queue.
-    fn try_read_channel_at_index(&mut self, index: usize) -> StageResult<Bytes> {
+    fn try_read_channel_at_index(&mut self, index: usize) -> PipelineResult<Bytes> {
         let channel_id = self.channel_queue[index];
-        let channel = self.channels.get(&channel_id).ok_or(StageError::ChannelNotFound)?;
-        let origin = self.origin().ok_or(StageError::MissingOrigin)?;
+        let channel =
+            self.channels.get(&channel_id).ok_or(PipelineError::ChannelBankEmpty.crit())?;
+        let origin = self.origin().ok_or(PipelineError::MissingOrigin.crit())?;
 
-        let timed_out = channel.open_block_number() + self.cfg.channel_timeout(origin.timestamp) <
-            origin.number;
+        let timed_out = channel.open_block_number() + self.cfg.channel_timeout(origin.timestamp)
+            < origin.number;
         if timed_out || !channel.is_ready() {
-            return Err(StageError::Eof);
+            return Err(PipelineError::Eof.temp());
         }
 
         let frame_data = channel.frame_data();
         self.channels.remove(&channel_id);
         self.channel_queue.remove(index);
 
-        frame_data.ok_or_else(|| StageError::Custom(anyhow!("Channel data is empty")))
+        frame_data.ok_or(PipelineError::ChannelBankEmpty.crit())
     }
 }
 
@@ -202,7 +203,7 @@ impl<P> OriginAdvancer for ChannelBank<P>
 where
     P: ChannelBankProvider + OriginAdvancer + OriginProvider + ResettableStage + Send + Debug,
 {
-    async fn advance_origin(&mut self) -> StageResult<()> {
+    async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.prev.advance_origin().await
     }
 }
@@ -212,15 +213,14 @@ impl<P> ChannelReaderProvider for ChannelBank<P>
 where
     P: ChannelBankProvider + OriginAdvancer + OriginProvider + ResettableStage + Send + Debug,
 {
-    async fn next_data(&mut self) -> StageResult<Option<Bytes>> {
+    async fn next_data(&mut self) -> PipelineResult<Option<Bytes>> {
         crate::timer!(START, STAGE_ADVANCE_RESPONSE_TIME, &["channel_bank"], timer);
         match self.read() {
-            Err(StageError::Eof) => {
-                // continue - we will attempt to load data into the channel bank
-            }
             Err(e) => {
-                crate::timer!(DISCARD, timer);
-                return Err(anyhow!("Error fetching next data from channel bank: {:?}", e).into());
+                if !matches!(e, StageErrorKind::Temporary(PipelineError::Eof)) {
+                    crate::timer!(DISCARD, timer);
+                    return Err(PipelineError::ChannelBankEmpty.crit());
+                }
             }
             data => return data,
         };
@@ -236,7 +236,7 @@ where
         let res = self.ingest_frame(frame);
         crate::timer!(DISCARD, timer);
         res?;
-        Err(StageError::NotEnoughData)
+        Err(PipelineError::NotEnoughData.temp())
     }
 }
 
@@ -258,7 +258,7 @@ where
         &mut self,
         block_info: BlockInfo,
         system_config: &SystemConfig,
-    ) -> StageResult<()> {
+    ) -> PipelineResult<()> {
         self.prev.reset(block_info, system_config).await?;
         self.channels.clear();
         self.channel_queue = VecDeque::with_capacity(10);
@@ -287,7 +287,7 @@ mod tests {
         let mut channel_bank = ChannelBank::new(cfg, mock);
         let frame = Frame::default();
         let err = channel_bank.ingest_frame(frame).unwrap_err();
-        assert_eq!(err, StageError::MissingOrigin);
+        assert_eq!(err, PipelineError::MissingOrigin.crit());
     }
 
     #[test]
@@ -346,9 +346,9 @@ mod tests {
         let cfg = Arc::new(RollupConfig::default());
         let mut channel_bank = ChannelBank::new(cfg, mock);
         let err = channel_bank.read().unwrap_err();
-        assert_eq!(err, StageError::Eof);
+        assert_eq!(err, PipelineError::Eof.temp());
         let err = channel_bank.next_data().await.unwrap_err();
-        assert_eq!(err, StageError::NotEnoughData);
+        assert_eq!(err, PipelineError::NotEnoughData.temp());
     }
 
     #[tokio::test]
@@ -367,7 +367,7 @@ mod tests {
 
             // Ingest first frame
             let err = channel_bank.next_data().await.unwrap_err();
-            assert_eq!(err, StageError::NotEnoughData);
+            assert_eq!(err, PipelineError::NotEnoughData.temp());
 
             for _ in 0..cfg.channel_timeout + 1 {
                 channel_bank.advance_origin().await.unwrap();

--- a/crates/derive/src/stages/channel_bank.rs
+++ b/crates/derive/src/stages/channel_bank.rs
@@ -90,8 +90,8 @@ where
         });
 
         // Check if the channel is not timed out. If it has, ignore the frame.
-        if current_channel.open_block_number() + self.cfg.channel_timeout(origin.timestamp)
-            < origin.number
+        if current_channel.open_block_number() + self.cfg.channel_timeout(origin.timestamp) <
+            origin.number
         {
             warn!(
                 target: "channel-bank",
@@ -184,8 +184,8 @@ where
             self.channels.get(&channel_id).ok_or(PipelineError::ChannelBankEmpty.crit())?;
         let origin = self.origin().ok_or(PipelineError::MissingOrigin.crit())?;
 
-        let timed_out = channel.open_block_number() + self.cfg.channel_timeout(origin.timestamp)
-            < origin.number;
+        let timed_out = channel.open_block_number() + self.cfg.channel_timeout(origin.timestamp) <
+            origin.number;
         if timed_out || !channel.is_ready() {
             return Err(PipelineError::Eof.temp());
         }

--- a/crates/derive/src/stages/channel_reader.rs
+++ b/crates/derive/src/stages/channel_reader.rs
@@ -174,8 +174,8 @@ impl BatchReader {
             }
 
             let compression_type = data[0];
-            if (compression_type & 0x0F) == ZLIB_DEFLATE_COMPRESSION_METHOD
-                || (compression_type & 0x0F) == ZLIB_RESERVED_COMPRESSION_METHOD
+            if (compression_type & 0x0F) == ZLIB_DEFLATE_COMPRESSION_METHOD ||
+                (compression_type & 0x0F) == ZLIB_RESERVED_COMPRESSION_METHOD
             {
                 self.decompressed = decompress_to_vec_zlib(&data).ok()?;
             } else if compression_type == CHANNEL_VERSION_BROTLI {

--- a/crates/derive/src/stages/channel_reader.rs
+++ b/crates/derive/src/stages/channel_reader.rs
@@ -221,7 +221,7 @@ impl<T: Into<Vec<u8>>> From<T> for BatchReader {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{errors::StageErrorKind, stages::test_utils::MockChannelReaderProvider};
+    use crate::{errors::PipelineErrorKind, stages::test_utils::MockChannelReaderProvider};
     use alloc::vec;
 
     fn new_compressed_batch_data() -> Bytes {
@@ -246,7 +246,7 @@ mod test {
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
         assert!(matches!(
             reader.next_batch().await.unwrap_err(),
-            StageErrorKind::Temporary(PipelineError::ChannelReaderEmpty)
+            PipelineErrorKind::Temporary(PipelineError::ChannelReaderEmpty)
         ));
         assert!(reader.next_batch.is_none());
     }

--- a/crates/derive/src/stages/channel_reader.rs
+++ b/crates/derive/src/stages/channel_reader.rs
@@ -2,20 +2,18 @@
 
 use crate::{
     batch::Batch,
-    errors::{StageError, StageResult},
+    errors::{PipelineError, PipelineResult},
     stages::{decompress_brotli, BatchQueueProvider},
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
 };
-use anyhow::anyhow;
-use op_alloy_genesis::{RollupConfig, SystemConfig};
-use op_alloy_protocol::BlockInfo;
-
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_primitives::Bytes;
 use alloy_rlp::Decodable;
 use async_trait::async_trait;
 use core::fmt::Debug;
 use miniz_oxide::inflate::decompress_to_vec_zlib;
+use op_alloy_genesis::{RollupConfig, SystemConfig};
+use op_alloy_protocol::BlockInfo;
 use tracing::{debug, error, warn};
 
 /// ZLIB Deflate Compression Method.
@@ -34,7 +32,7 @@ pub trait ChannelReaderProvider {
     /// of the channel bank prior to loading data in (unlike most other stages). This is to
     /// ensure maintain consistency around channel bank pruning which depends upon the order
     /// of operations.
-    async fn next_data(&mut self) -> StageResult<Option<Bytes>>;
+    async fn next_data(&mut self) -> PipelineResult<Option<Bytes>>;
 }
 
 /// [ChannelReader] is a stateful stage that does the following:
@@ -62,10 +60,10 @@ where
     }
 
     /// Creates the batch reader from available channel data.
-    async fn set_batch_reader(&mut self) -> StageResult<()> {
+    async fn set_batch_reader(&mut self) -> PipelineResult<()> {
         if self.next_batch.is_none() {
             let channel =
-                self.prev.next_data().await?.ok_or(StageError::Temporary(anyhow!("No channel")))?;
+                self.prev.next_data().await?.ok_or(PipelineError::ChannelReaderEmpty.temp())?;
             self.next_batch = Some(BatchReader::from(&channel[..]));
         }
         Ok(())
@@ -83,7 +81,7 @@ impl<P> OriginAdvancer for ChannelReader<P>
 where
     P: ChannelReaderProvider + OriginAdvancer + OriginProvider + ResettableStage + Send + Debug,
 {
-    async fn advance_origin(&mut self) -> StageResult<()> {
+    async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.prev.advance_origin().await
     }
 }
@@ -93,7 +91,7 @@ impl<P> BatchQueueProvider for ChannelReader<P>
 where
     P: ChannelReaderProvider + OriginAdvancer + OriginProvider + ResettableStage + Send + Debug,
 {
-    async fn next_batch(&mut self) -> StageResult<Batch> {
+    async fn next_batch(&mut self) -> PipelineResult<Batch> {
         crate::timer!(START, STAGE_ADVANCE_RESPONSE_TIME, &["channel_reader"], timer);
         if let Err(e) = self.set_batch_reader().await {
             debug!(target: "channel-reader", "Failed to set batch reader: {:?}", e);
@@ -106,7 +104,7 @@ where
             .as_mut()
             .expect("Cannot be None")
             .next_batch(self.cfg.as_ref())
-            .ok_or(StageError::NotEnoughData)
+            .ok_or(PipelineError::NotEnoughData.temp())
         {
             Ok(batch) => Ok(batch),
             Err(e) => {
@@ -132,7 +130,7 @@ impl<P> ResettableStage for ChannelReader<P>
 where
     P: ChannelReaderProvider + OriginAdvancer + OriginProvider + ResettableStage + Debug + Send,
 {
-    async fn reset(&mut self, base: BlockInfo, cfg: &SystemConfig) -> StageResult<()> {
+    async fn reset(&mut self, base: BlockInfo, cfg: &SystemConfig) -> PipelineResult<()> {
         self.prev.reset(base, cfg).await?;
         self.next_channel();
         crate::inc!(STAGE_RESETS, &["channel-reader"]);
@@ -176,8 +174,8 @@ impl BatchReader {
             }
 
             let compression_type = data[0];
-            if (compression_type & 0x0F) == ZLIB_DEFLATE_COMPRESSION_METHOD ||
-                (compression_type & 0x0F) == ZLIB_RESERVED_COMPRESSION_METHOD
+            if (compression_type & 0x0F) == ZLIB_DEFLATE_COMPRESSION_METHOD
+                || (compression_type & 0x0F) == ZLIB_RESERVED_COMPRESSION_METHOD
             {
                 self.decompressed = decompress_to_vec_zlib(&data).ok()?;
             } else if compression_type == CHANNEL_VERSION_BROTLI {
@@ -223,7 +221,7 @@ impl<T: Into<Vec<u8>>> From<T> for BatchReader {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::stages::test_utils::MockChannelReaderProvider;
+    use crate::{errors::StageErrorKind, stages::test_utils::MockChannelReaderProvider};
     use alloc::vec;
 
     fn new_compressed_batch_data() -> Bytes {
@@ -236,9 +234,9 @@ mod test {
 
     #[tokio::test]
     async fn test_next_batch_batch_reader_set_fails() {
-        let mock = MockChannelReaderProvider::new(vec![Err(StageError::Eof)]);
+        let mock = MockChannelReaderProvider::new(vec![Err(PipelineError::Eof.temp())]);
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
-        assert_eq!(reader.next_batch().await, Err(StageError::Eof));
+        assert_eq!(reader.next_batch().await, Err(PipelineError::Eof.temp()));
         assert!(reader.next_batch.is_none());
     }
 
@@ -246,7 +244,10 @@ mod test {
     async fn test_next_batch_batch_reader_no_data() {
         let mock = MockChannelReaderProvider::new(vec![Ok(None)]);
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
-        assert!(matches!(reader.next_batch().await.unwrap_err(), StageError::Temporary(_)));
+        assert!(matches!(
+            reader.next_batch().await.unwrap_err(),
+            StageErrorKind::Temporary(PipelineError::ChannelReaderEmpty)
+        ));
         assert!(reader.next_batch.is_none());
     }
 
@@ -256,7 +257,7 @@ mod test {
         let second = first.split_to(first.len() / 2);
         let mock = MockChannelReaderProvider::new(vec![Ok(Some(first)), Ok(Some(second))]);
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
-        assert_eq!(reader.next_batch().await, Err(StageError::NotEnoughData));
+        assert_eq!(reader.next_batch().await, Err(PipelineError::NotEnoughData.temp()));
         assert!(reader.next_batch.is_none());
     }
 

--- a/crates/derive/src/stages/frame_queue.rs
+++ b/crates/derive/src/stages/frame_queue.rs
@@ -72,7 +72,7 @@ where
         if self.queue.is_empty() {
             match self.prev.next_data().await {
                 Ok(data) => {
-                    if let Ok(frames) = into_frames(Ok(data)) {
+                    if let Ok(frames) = Frame::parse_frames(&data.into()) {
                         crate::inc!(DERIVED_FRAMES_COUNT, frames.len() as f64, &["success"]);
                         self.queue.extend(frames);
                     } else {

--- a/crates/derive/src/stages/l1_retrieval.rs
+++ b/crates/derive/src/stages/l1_retrieval.rs
@@ -1,7 +1,7 @@
 //! Contains the [L1Retrieval] stage of the derivation pipeline.
 
 use crate::{
-    errors::{PipelineError, PipelineResult, StageErrorKind},
+    errors::{PipelineError, PipelineErrorKind, PipelineResult},
     stages::FrameQueueProvider,
     traits::{
         AsyncIterator, DataAvailabilityProvider, OriginAdvancer, OriginProvider, ResettableStage,
@@ -98,7 +98,7 @@ where
         match self.data.as_mut().expect("Cannot be None").next().await {
             Ok(data) => Ok(data),
             Err(e) => {
-                if let StageErrorKind::Temporary(PipelineError::Eof) = e {
+                if let PipelineErrorKind::Temporary(PipelineError::Eof) = e {
                     self.data = None;
                 }
                 Err(e)

--- a/crates/derive/src/stages/l1_retrieval.rs
+++ b/crates/derive/src/stages/l1_retrieval.rs
@@ -1,7 +1,7 @@
 //! Contains the [L1Retrieval] stage of the derivation pipeline.
 
 use crate::{
-    errors::{StageError, StageResult},
+    errors::{PipelineError, PipelineResult, StageErrorKind},
     stages::FrameQueueProvider,
     traits::{
         AsyncIterator, DataAvailabilityProvider, OriginAdvancer, OriginProvider, ResettableStage,
@@ -9,7 +9,6 @@ use crate::{
 };
 use alloc::boxed::Box;
 use alloy_primitives::Address;
-use anyhow::anyhow;
 use async_trait::async_trait;
 use op_alloy_genesis::SystemConfig;
 use op_alloy_protocol::BlockInfo;
@@ -24,7 +23,7 @@ pub trait L1RetrievalProvider {
     /// complete and the [BlockInfo] has been consumed, an [StageError::Eof] error is returned.
     ///
     /// [L1Traversal]: crate::stages::L1Traversal
-    async fn next_l1_block(&mut self) -> StageResult<Option<BlockInfo>>;
+    async fn next_l1_block(&mut self) -> PipelineResult<Option<BlockInfo>>;
 
     /// Returns the batcher [Address] from the [op_alloy_genesis::SystemConfig].
     fn batcher_addr(&self) -> Address;
@@ -73,7 +72,7 @@ where
     DAP: DataAvailabilityProvider + Send,
     P: L1RetrievalProvider + OriginAdvancer + OriginProvider + ResettableStage + Send,
 {
-    async fn advance_origin(&mut self) -> StageResult<()> {
+    async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.prev.advance_origin().await
     }
 }
@@ -86,23 +85,24 @@ where
 {
     type Item = DAP::Item;
 
-    async fn next_data(&mut self) -> StageResult<Self::Item> {
+    async fn next_data(&mut self) -> PipelineResult<Self::Item> {
         if self.data.is_none() {
             let next = self
                 .prev
                 .next_l1_block()
                 .await? // SAFETY: This question mark bubbles up the Eof error.
-                .ok_or_else(|| anyhow!("No block to retrieve data from"))?;
+                .ok_or(PipelineError::MissingL1Data.temp())?; // TODO: Check if this is actually temp
             self.data = Some(self.provider.open_data(&next).await?);
         }
 
         match self.data.as_mut().expect("Cannot be None").next().await {
             Ok(data) => Ok(data),
-            Err(StageError::Eof) => {
-                self.data = None;
-                Err(StageError::Eof)
+            Err(e) => {
+                if let StageErrorKind::Temporary(PipelineError::Eof) = e {
+                    self.data = None;
+                }
+                Err(e)
             }
-            Err(e) => Err(e),
         }
     }
 }
@@ -123,7 +123,7 @@ where
     DAP: DataAvailabilityProvider + Send,
     P: L1RetrievalProvider + OriginAdvancer + OriginProvider + ResettableStage + Send,
 {
-    async fn reset(&mut self, base: BlockInfo, cfg: &SystemConfig) -> StageResult<()> {
+    async fn reset(&mut self, base: BlockInfo, cfg: &SystemConfig) -> PipelineResult<()> {
         self.prev.reset(base, cfg).await?;
         self.data = Some(self.provider.open_data(&base).await?);
         crate::inc!(STAGE_RESETS, &["l1-retrieval"]);
@@ -153,7 +153,7 @@ mod tests {
     #[tokio::test]
     async fn test_l1_retrieval_next_data() {
         let traversal = new_populated_test_traversal();
-        let results = vec![Err(StageError::Eof), Ok(Bytes::default())];
+        let results = vec![Err(PipelineError::Eof.temp()), Ok(Bytes::default())];
         let dap = TestDAP { results, batch_inbox_address: Address::default() };
         let mut retrieval = L1Retrieval::new(traversal, dap);
         assert_eq!(retrieval.data, None);
@@ -166,7 +166,7 @@ mod tests {
         assert_eq!(retrieval_data.open_data_calls[0].1, Address::default());
         // Data should be reset to none and the error should be bubbled up.
         let data = retrieval.next_data().await.unwrap_err();
-        assert_eq!(data, StageError::Eof);
+        assert_eq!(data, PipelineError::Eof.temp());
         assert!(retrieval.data.is_none());
     }
 
@@ -193,13 +193,13 @@ mod tests {
     async fn test_l1_retrieval_existing_data_errors() {
         let data = TestIter {
             open_data_calls: vec![(BlockInfo::default(), Address::default())],
-            results: vec![Err(StageError::Eof)],
+            results: vec![Err(PipelineError::Eof.temp())],
         };
         let traversal = new_populated_test_traversal();
         let dap = TestDAP { results: vec![], batch_inbox_address: Address::default() };
         let mut retrieval = L1Retrieval { prev: traversal, provider: dap, data: Some(data) };
         let data = retrieval.next_data().await.unwrap_err();
-        assert_eq!(data, StageError::Eof);
+        assert_eq!(data, PipelineError::Eof.temp());
         assert!(retrieval.data.is_none());
     }
 }

--- a/crates/derive/src/stages/l1_retrieval.rs
+++ b/crates/derive/src/stages/l1_retrieval.rs
@@ -20,7 +20,7 @@ pub trait L1RetrievalProvider {
     /// Returns the next L1 [BlockInfo] in the [L1Traversal] stage, if the stage is not complete.
     /// This function can only be called once while the stage is in progress, and will return
     /// [`None`] on subsequent calls unless the stage is reset or complete. If the stage is
-    /// complete and the [BlockInfo] has been consumed, an [StageError::Eof] error is returned.
+    /// complete and the [BlockInfo] has been consumed, an [PipelineError::Eof] error is returned.
     ///
     /// [L1Traversal]: crate::stages::L1Traversal
     async fn next_l1_block(&mut self) -> PipelineResult<Option<BlockInfo>>;
@@ -91,7 +91,7 @@ where
                 .prev
                 .next_l1_block()
                 .await? // SAFETY: This question mark bubbles up the Eof error.
-                .ok_or(PipelineError::MissingL1Data.temp())?; // TODO: Check if this is actually temp
+                .ok_or(PipelineError::MissingL1Data.temp())?;
             self.data = Some(self.provider.open_data(&next).await?);
         }
 

--- a/crates/derive/src/stages/l1_traversal.rs
+++ b/crates/derive/src/stages/l1_traversal.rs
@@ -5,7 +5,7 @@ use crate::{
     stages::L1RetrievalProvider,
     traits::{ChainProvider, OriginAdvancer, OriginProvider, ResettableStage},
 };
-use alloc::{boxed::Box, sync::Arc, string::ToString};
+use alloc::{boxed::Box, string::ToString, sync::Arc};
 use alloy_primitives::Address;
 use async_trait::async_trait;
 use op_alloy_genesis::{RollupConfig, SystemConfig};
@@ -135,9 +135,9 @@ impl<F: ChainProvider + Send> ResettableStage for L1Traversal<F> {
 pub(crate) mod tests {
     use super::*;
     use crate::{
+        errors::StageErrorKind,
         params::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC},
         traits::test_utils::TestChainProvider,
-        errors::StageErrorKind
     };
     use alloc::vec;
     use alloy_consensus::Receipt;
@@ -215,7 +215,10 @@ pub(crate) mod tests {
         let mut traversal = new_test_traversal(blocks, vec![]);
         assert_eq!(traversal.next_l1_block().await.unwrap(), Some(BlockInfo::default()));
         assert_eq!(traversal.next_l1_block().await.unwrap_err(), PipelineError::Eof.temp());
-        matches!(traversal.advance_origin().await.unwrap_err(), StageErrorKind::Temporary(PipelineError::Provider(_)));
+        matches!(
+            traversal.advance_origin().await.unwrap_err(),
+            StageErrorKind::Temporary(PipelineError::Provider(_))
+        );
     }
 
     #[tokio::test]
@@ -235,7 +238,10 @@ pub(crate) mod tests {
         let mut traversal = new_test_traversal(vec![], vec![]);
         assert_eq!(traversal.next_l1_block().await.unwrap(), Some(BlockInfo::default()));
         assert_eq!(traversal.next_l1_block().await.unwrap_err(), PipelineError::Eof.temp());
-        matches!(traversal.advance_origin().await.unwrap_err(), StageErrorKind::Temporary(PipelineError::Provider(_)));
+        matches!(
+            traversal.advance_origin().await.unwrap_err(),
+            StageErrorKind::Temporary(PipelineError::Provider(_))
+        );
     }
 
     #[tokio::test]

--- a/crates/derive/src/stages/l1_traversal.rs
+++ b/crates/derive/src/stages/l1_traversal.rs
@@ -135,7 +135,7 @@ impl<F: ChainProvider + Send> ResettableStage for L1Traversal<F> {
 pub(crate) mod tests {
     use super::*;
     use crate::{
-        errors::StageErrorKind,
+        errors::PipelineErrorKind,
         params::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC},
         traits::test_utils::TestChainProvider,
     };
@@ -217,7 +217,7 @@ pub(crate) mod tests {
         assert_eq!(traversal.next_l1_block().await.unwrap_err(), PipelineError::Eof.temp());
         matches!(
             traversal.advance_origin().await.unwrap_err(),
-            StageErrorKind::Temporary(PipelineError::Provider(_))
+            PipelineErrorKind::Temporary(PipelineError::Provider(_))
         );
     }
 
@@ -240,7 +240,7 @@ pub(crate) mod tests {
         assert_eq!(traversal.next_l1_block().await.unwrap_err(), PipelineError::Eof.temp());
         matches!(
             traversal.advance_origin().await.unwrap_err(),
-            StageErrorKind::Temporary(PipelineError::Provider(_))
+            PipelineErrorKind::Temporary(PipelineError::Provider(_))
         );
     }
 
@@ -257,7 +257,7 @@ pub(crate) mod tests {
         // Only the second block should fail since the second receipt
         // contains invalid logs that will error for a system config update.
         let err = traversal.advance_origin().await.unwrap_err();
-        matches!(err, StageErrorKind::Critical(PipelineError::SystemConfigUpdate(_)));
+        matches!(err, PipelineErrorKind::Critical(PipelineError::SystemConfigUpdate(_)));
     }
 
     #[tokio::test]

--- a/crates/derive/src/stages/l1_traversal.rs
+++ b/crates/derive/src/stages/l1_traversal.rs
@@ -1,7 +1,7 @@
 //! Contains the [L1Traversal] stage of the derivation pipeline.
 
 use crate::{
-    errors::{StageError, StageResult},
+    errors::{PipelineError, PipelineResult, ResetError},
     stages::L1RetrievalProvider,
     traits::{ChainProvider, OriginAdvancer, OriginProvider, ResettableStage},
 };
@@ -39,12 +39,12 @@ impl<F: ChainProvider + Send> L1RetrievalProvider for L1Traversal<F> {
         self.system_config.batcher_address
     }
 
-    async fn next_l1_block(&mut self) -> StageResult<Option<BlockInfo>> {
+    async fn next_l1_block(&mut self) -> PipelineResult<Option<BlockInfo>> {
         if !self.done {
             self.done = true;
             Ok(self.block)
         } else {
-            Err(StageError::Eof)
+            Err(PipelineError::Eof.temp())
         }
     }
 }
@@ -73,30 +73,30 @@ impl<F: ChainProvider + Send> OriginAdvancer for L1Traversal<F> {
     /// Advances the internal state of the [L1Traversal] stage to the next L1 block.
     /// This function fetches the next L1 [BlockInfo] from the data source and updates the
     /// [SystemConfig] with the receipts from the block.
-    async fn advance_origin(&mut self) -> StageResult<()> {
+    async fn advance_origin(&mut self) -> PipelineResult<()> {
         // Pull the next block or return EOF.
-        // StageError::EOF has special handling further up the pipeline.
+        // PipelineError::EOF has special handling further up the pipeline.
         let block = match self.block {
             Some(block) => block,
             None => {
                 warn!(target: "l1-traversal",  "Missing current block, can't advance origin with no reference.");
-                return Err(StageError::Eof);
+                return Err(PipelineError::Eof.temp());
             }
         };
         let next_l1_origin = match self.data_source.block_info_by_number(block.number + 1).await {
             Ok(block) => block,
-            Err(e) => return Err(StageError::BlockInfoFetch(e)),
+            Err(e) => return Err(PipelineError::BlockInfoFetch(e)),
         };
 
         // Check block hashes for reorgs.
         if block.hash != next_l1_origin.parent_hash {
-            return Err(StageError::ReorgDetected(block.hash, next_l1_origin.parent_hash));
+            return Err(ResetError::ReorgDetected(block.hash, next_l1_origin.parent_hash).into());
         }
 
         // Fetch receipts for the next l1 block and update the system config.
         let receipts = match self.data_source.receipts_by_hash(next_l1_origin.hash).await {
             Ok(receipts) => receipts,
-            Err(e) => return Err(StageError::ReceiptFetch(e)),
+            Err(e) => return Err(PipelineError::ReceiptFetch(e)),
         };
 
         if let Err(e) = self.system_config.update_with_receipts(
@@ -104,7 +104,7 @@ impl<F: ChainProvider + Send> OriginAdvancer for L1Traversal<F> {
             &self.rollup_config,
             next_l1_origin.timestamp,
         ) {
-            return Err(StageError::SystemConfigUpdate(e));
+            return Err(PipelineError::SystemConfigUpdate(e).crit());
         }
 
         crate::set!(ORIGIN_GAUGE, next_l1_origin.number as i64);
@@ -122,7 +122,7 @@ impl<F: ChainProvider> OriginProvider for L1Traversal<F> {
 
 #[async_trait]
 impl<F: ChainProvider + Send> ResettableStage for L1Traversal<F> {
-    async fn reset(&mut self, base: BlockInfo, cfg: &SystemConfig) -> StageResult<()> {
+    async fn reset(&mut self, base: BlockInfo, cfg: &SystemConfig) -> PipelineResult<()> {
         self.block = Some(base);
         self.done = false;
         self.system_config = *cfg;
@@ -137,6 +137,7 @@ pub(crate) mod tests {
     use crate::{
         params::{CONFIG_UPDATE_EVENT_VERSION_0, CONFIG_UPDATE_TOPIC},
         traits::test_utils::TestChainProvider,
+        errors::StageErrorKind
     };
     use alloc::vec;
     use alloy_consensus::Receipt;
@@ -204,7 +205,7 @@ pub(crate) mod tests {
         let receipts = new_receipts();
         let mut traversal = new_test_traversal(blocks, receipts);
         assert_eq!(traversal.next_l1_block().await.unwrap(), Some(BlockInfo::default()));
-        assert_eq!(traversal.next_l1_block().await.unwrap_err(), StageError::Eof);
+        assert_eq!(traversal.next_l1_block().await.unwrap_err(), PipelineError::Eof.temp());
         assert!(traversal.advance_origin().await.is_ok());
     }
 
@@ -213,8 +214,8 @@ pub(crate) mod tests {
         let blocks = vec![BlockInfo::default(), BlockInfo::default()];
         let mut traversal = new_test_traversal(blocks, vec![]);
         assert_eq!(traversal.next_l1_block().await.unwrap(), Some(BlockInfo::default()));
-        assert_eq!(traversal.next_l1_block().await.unwrap_err(), StageError::Eof);
-        matches!(traversal.advance_origin().await.unwrap_err(), StageError::ReceiptFetch(_));
+        assert_eq!(traversal.next_l1_block().await.unwrap_err(), PipelineError::Eof.temp());
+        matches!(traversal.advance_origin().await.unwrap_err(), PipelineError::ReceiptFetch(_));
     }
 
     #[tokio::test]
@@ -226,15 +227,15 @@ pub(crate) mod tests {
         let mut traversal = new_test_traversal(blocks, receipts);
         assert!(traversal.advance_origin().await.is_ok());
         let err = traversal.advance_origin().await.unwrap_err();
-        assert_eq!(err, StageError::ReorgDetected(block.hash, block.parent_hash));
+        assert_eq!(err, ResetError::ReorgDetected(block.hash, block.parent_hash).into());
     }
 
     #[tokio::test]
     async fn test_l1_traversal_missing_blocks() {
         let mut traversal = new_test_traversal(vec![], vec![]);
         assert_eq!(traversal.next_l1_block().await.unwrap(), Some(BlockInfo::default()));
-        assert_eq!(traversal.next_l1_block().await.unwrap_err(), StageError::Eof);
-        matches!(traversal.advance_origin().await.unwrap_err(), StageError::BlockInfoFetch(_));
+        assert_eq!(traversal.next_l1_block().await.unwrap_err(), PipelineError::Eof.temp());
+        matches!(traversal.advance_origin().await.unwrap_err(), PipelineError::BlockInfoFetch(_));
     }
 
     #[tokio::test]
@@ -250,7 +251,7 @@ pub(crate) mod tests {
         // Only the second block should fail since the second receipt
         // contains invalid logs that will error for a system config update.
         let err = traversal.advance_origin().await.unwrap_err();
-        matches!(err, StageError::SystemConfigUpdate(_));
+        matches!(err, StageErrorKind::Critical(PipelineError::SystemConfigUpdate(_)));
     }
 
     #[tokio::test]
@@ -259,7 +260,7 @@ pub(crate) mod tests {
         let receipts = new_receipts();
         let mut traversal = new_test_traversal(blocks, receipts);
         assert_eq!(traversal.next_l1_block().await.unwrap(), Some(BlockInfo::default()));
-        assert_eq!(traversal.next_l1_block().await.unwrap_err(), StageError::Eof);
+        assert_eq!(traversal.next_l1_block().await.unwrap_err(), PipelineError::Eof.temp());
         assert!(traversal.advance_origin().await.is_ok());
         let expected = address!("000000000000000000000000000000000000bEEF");
         assert_eq!(traversal.system_config.batcher_address, expected);

--- a/crates/derive/src/stages/test_utils/attributes_queue.rs
+++ b/crates/derive/src/stages/test_utils/attributes_queue.rs
@@ -6,7 +6,7 @@ use crate::{
     stages::attributes_queue::{AttributesBuilder, AttributesProvider},
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
 };
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, vec::Vec, string::ToString};
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use op_alloy_genesis::SystemConfig;

--- a/crates/derive/src/stages/test_utils/attributes_queue.rs
+++ b/crates/derive/src/stages/test_utils/attributes_queue.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     batch::SingleBatch,
-    errors::{BuilderError, PipelineError, PipelineResult, StageErrorKind},
+    errors::{BuilderError, PipelineError, PipelineErrorKind, PipelineResult},
     stages::attributes_queue::{AttributesBuilder, AttributesProvider},
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
 };
@@ -31,9 +31,9 @@ impl AttributesBuilder for MockAttributesBuilder {
         match self.attributes.pop() {
             Some(Ok(attrs)) => Ok(attrs),
             Some(Err(err)) => {
-                Err(StageErrorKind::Temporary(BuilderError::Custom(err.to_string()).into()))
+                Err(PipelineErrorKind::Temporary(BuilderError::Custom(err.to_string()).into()))
             }
-            None => Err(StageErrorKind::Critical(BuilderError::AttributesUnavailable.into())),
+            None => Err(PipelineErrorKind::Critical(BuilderError::AttributesUnavailable.into())),
         }
     }
 }

--- a/crates/derive/src/stages/test_utils/attributes_queue.rs
+++ b/crates/derive/src/stages/test_utils/attributes_queue.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     batch::SingleBatch,
-    errors::{BuilderError, StageError, StageResult},
+    errors::{BuilderError, PipelineError, PipelineResult, StageErrorKind},
     stages::attributes_queue::{AttributesBuilder, AttributesProvider},
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
 };
@@ -27,11 +27,11 @@ impl AttributesBuilder for MockAttributesBuilder {
         &mut self,
         _l2_parent: L2BlockInfo,
         _epoch: BlockNumHash,
-    ) -> Result<OptimismPayloadAttributes, BuilderError> {
+    ) -> PipelineResult<OptimismPayloadAttributes> {
         match self.attributes.pop() {
             Some(Ok(attrs)) => Ok(attrs),
-            Some(Err(err)) => Err(BuilderError::Custom(err)),
-            None => Err(BuilderError::Custom(anyhow::anyhow!("no attributes available"))),
+            Some(Err(err)) => Err(StageErrorKind::Temporary(BuilderError::Custom(err.to_string()).into())),
+            None => Err(StageErrorKind::Critical(BuilderError::AttributesUnavailable.into())),
         }
     }
 }
@@ -42,7 +42,7 @@ pub struct MockAttributesProvider {
     /// The origin of the L1 block.
     origin: Option<BlockInfo>,
     /// A list of batches to return.
-    batches: Vec<StageResult<SingleBatch>>,
+    batches: Vec<PipelineResult<SingleBatch>>,
 }
 
 impl OriginProvider for MockAttributesProvider {
@@ -53,22 +53,22 @@ impl OriginProvider for MockAttributesProvider {
 
 #[async_trait]
 impl OriginAdvancer for MockAttributesProvider {
-    async fn advance_origin(&mut self) -> StageResult<()> {
+    async fn advance_origin(&mut self) -> PipelineResult<()> {
         Ok(())
     }
 }
 
 #[async_trait]
 impl ResettableStage for MockAttributesProvider {
-    async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> StageResult<()> {
+    async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> PipelineResult<()> {
         Ok(())
     }
 }
 
 #[async_trait]
 impl AttributesProvider for MockAttributesProvider {
-    async fn next_batch(&mut self, _parent: L2BlockInfo) -> StageResult<SingleBatch> {
-        self.batches.pop().ok_or(StageError::Eof)?
+    async fn next_batch(&mut self, _parent: L2BlockInfo) -> PipelineResult<SingleBatch> {
+        self.batches.pop().ok_or(PipelineError::Eof.temp())?
     }
 
     fn is_last_in_span(&self) -> bool {
@@ -79,7 +79,7 @@ impl AttributesProvider for MockAttributesProvider {
 /// Creates a new [`MockAttributesProvider`] with the given origin and batches.
 pub fn new_attributes_provider(
     origin: Option<BlockInfo>,
-    batches: Vec<StageResult<SingleBatch>>,
+    batches: Vec<PipelineResult<SingleBatch>>,
 ) -> MockAttributesProvider {
     MockAttributesProvider { origin, batches }
 }

--- a/crates/derive/src/stages/test_utils/attributes_queue.rs
+++ b/crates/derive/src/stages/test_utils/attributes_queue.rs
@@ -30,7 +30,9 @@ impl AttributesBuilder for MockAttributesBuilder {
     ) -> PipelineResult<OptimismPayloadAttributes> {
         match self.attributes.pop() {
             Some(Ok(attrs)) => Ok(attrs),
-            Some(Err(err)) => Err(StageErrorKind::Temporary(BuilderError::Custom(err.to_string()).into())),
+            Some(Err(err)) => {
+                Err(StageErrorKind::Temporary(BuilderError::Custom(err.to_string()).into()))
+            }
             None => Err(StageErrorKind::Critical(BuilderError::AttributesUnavailable.into())),
         }
     }

--- a/crates/derive/src/stages/test_utils/attributes_queue.rs
+++ b/crates/derive/src/stages/test_utils/attributes_queue.rs
@@ -6,7 +6,7 @@ use crate::{
     stages::attributes_queue::{AttributesBuilder, AttributesProvider},
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
 };
-use alloc::{boxed::Box, vec::Vec, string::ToString};
+use alloc::{boxed::Box, string::ToString, vec::Vec};
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use op_alloy_genesis::SystemConfig;

--- a/crates/derive/src/stages/test_utils/batch_queue.rs
+++ b/crates/derive/src/stages/test_utils/batch_queue.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     batch::Batch,
-    errors::{StageError, StageResult},
+    errors::{PipelineError, PipelineResult},
     stages::batch_queue::BatchQueueProvider,
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
 };
@@ -17,12 +17,12 @@ pub struct MockBatchQueueProvider {
     /// The origin of the L1 block.
     pub origin: Option<BlockInfo>,
     /// A list of batches to return.
-    pub batches: Vec<StageResult<Batch>>,
+    pub batches: Vec<PipelineResult<Batch>>,
 }
 
 impl MockBatchQueueProvider {
     /// Creates a new [MockBatchQueueProvider] with the given origin and batches.
-    pub fn new(batches: Vec<StageResult<Batch>>) -> Self {
+    pub fn new(batches: Vec<PipelineResult<Batch>>) -> Self {
         Self { origin: Some(BlockInfo::default()), batches }
     }
 }
@@ -35,21 +35,21 @@ impl OriginProvider for MockBatchQueueProvider {
 
 #[async_trait]
 impl BatchQueueProvider for MockBatchQueueProvider {
-    async fn next_batch(&mut self) -> StageResult<Batch> {
-        self.batches.pop().ok_or(StageError::Eof)?
+    async fn next_batch(&mut self) -> PipelineResult<Batch> {
+        self.batches.pop().ok_or(PipelineError::Eof)?
     }
 }
 
 #[async_trait]
 impl OriginAdvancer for MockBatchQueueProvider {
-    async fn advance_origin(&mut self) -> StageResult<()> {
+    async fn advance_origin(&mut self) -> PipelineResult<()> {
         Ok(())
     }
 }
 
 #[async_trait]
 impl ResettableStage for MockBatchQueueProvider {
-    async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> StageResult<()> {
+    async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> PipelineResult<()> {
         Ok(())
     }
 }

--- a/crates/derive/src/stages/test_utils/batch_queue.rs
+++ b/crates/derive/src/stages/test_utils/batch_queue.rs
@@ -36,7 +36,7 @@ impl OriginProvider for MockBatchQueueProvider {
 #[async_trait]
 impl BatchQueueProvider for MockBatchQueueProvider {
     async fn next_batch(&mut self) -> PipelineResult<Batch> {
-        self.batches.pop().ok_or(PipelineError::Eof)?
+        self.batches.pop().ok_or(PipelineError::Eof.temp())?
     }
 }
 

--- a/crates/derive/src/stages/test_utils/channel_bank.rs
+++ b/crates/derive/src/stages/test_utils/channel_bank.rs
@@ -1,7 +1,7 @@
 //! Mock testing utilities for the [ChannelBank] stage.
 
 use crate::{
-    errors::{StageError, StageResult},
+    errors::{PipelineError, PipelineResult},
     stages::ChannelBankProvider,
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
 };
@@ -14,14 +14,14 @@ use op_alloy_protocol::{BlockInfo, Frame};
 #[derive(Debug, Default)]
 pub struct MockChannelBankProvider {
     /// The data to return.
-    pub data: Vec<StageResult<Frame>>,
+    pub data: Vec<PipelineResult<Frame>>,
     /// The block info
     pub block_info: Option<BlockInfo>,
 }
 
 impl MockChannelBankProvider {
     /// Creates a new [MockChannelBankProvider] with the given data.
-    pub fn new(data: Vec<StageResult<Frame>>) -> Self {
+    pub fn new(data: Vec<PipelineResult<Frame>>) -> Self {
         Self { data, block_info: Some(BlockInfo::default()) }
     }
 }
@@ -34,7 +34,7 @@ impl OriginProvider for MockChannelBankProvider {
 
 #[async_trait]
 impl OriginAdvancer for MockChannelBankProvider {
-    async fn advance_origin(&mut self) -> StageResult<()> {
+    async fn advance_origin(&mut self) -> PipelineResult<()> {
         self.block_info = self.block_info.map(|mut bi| {
             bi.number += 1;
             bi
@@ -45,14 +45,14 @@ impl OriginAdvancer for MockChannelBankProvider {
 
 #[async_trait]
 impl ChannelBankProvider for MockChannelBankProvider {
-    async fn next_frame(&mut self) -> StageResult<Frame> {
-        self.data.pop().unwrap_or(Err(StageError::Eof))
+    async fn next_frame(&mut self) -> PipelineResult<Frame> {
+        self.data.pop().unwrap_or(Err(PipelineError::Eof.temp()))
     }
 }
 
 #[async_trait]
 impl ResettableStage for MockChannelBankProvider {
-    async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> StageResult<()> {
+    async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> PipelineResult<()> {
         Ok(())
     }
 }

--- a/crates/derive/src/stages/test_utils/channel_reader.rs
+++ b/crates/derive/src/stages/test_utils/channel_reader.rs
@@ -1,7 +1,7 @@
 //! Test utilities for the [ChannelReader] stage.
 
 use crate::{
-    errors::{StageError, StageResult},
+    errors::{PipelineError, PipelineResult},
     stages::ChannelReaderProvider,
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
 };
@@ -15,14 +15,14 @@ use op_alloy_protocol::BlockInfo;
 #[derive(Debug, Default)]
 pub struct MockChannelReaderProvider {
     /// The data to return.
-    pub data: Vec<StageResult<Option<Bytes>>>,
+    pub data: Vec<PipelineResult<Option<Bytes>>>,
     /// The origin block info
     pub block_info: Option<BlockInfo>,
 }
 
 impl MockChannelReaderProvider {
     /// Creates a new [MockChannelReaderProvider] with the given data.
-    pub fn new(data: Vec<StageResult<Option<Bytes>>>) -> Self {
+    pub fn new(data: Vec<PipelineResult<Option<Bytes>>>) -> Self {
         Self { data, block_info: Some(BlockInfo::default()) }
     }
 }
@@ -35,21 +35,21 @@ impl OriginProvider for MockChannelReaderProvider {
 
 #[async_trait]
 impl OriginAdvancer for MockChannelReaderProvider {
-    async fn advance_origin(&mut self) -> StageResult<()> {
+    async fn advance_origin(&mut self) -> PipelineResult<()> {
         Ok(())
     }
 }
 
 #[async_trait]
 impl ChannelReaderProvider for MockChannelReaderProvider {
-    async fn next_data(&mut self) -> StageResult<Option<Bytes>> {
-        self.data.pop().unwrap_or(Err(StageError::Eof))
+    async fn next_data(&mut self) -> PipelineResult<Option<Bytes>> {
+        self.data.pop().unwrap_or(Err(PipelineError::Eof.temp()))
     }
 }
 
 #[async_trait]
 impl ResettableStage for MockChannelReaderProvider {
-    async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> StageResult<()> {
+    async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> PipelineResult<()> {
         Ok(())
     }
 }

--- a/crates/derive/src/stages/test_utils/frame_queue.rs
+++ b/crates/derive/src/stages/test_utils/frame_queue.rs
@@ -1,7 +1,7 @@
 //! Mock types for the [FrameQueue] stage.
 
 use crate::{
-    errors::{StageError, StageResult},
+    errors::{PipelineError, PipelineResult},
     stages::FrameQueueProvider,
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
 };
@@ -15,12 +15,12 @@ use op_alloy_protocol::BlockInfo;
 #[derive(Debug, Default)]
 pub struct MockFrameQueueProvider {
     /// The data to return.
-    pub data: Vec<StageResult<Bytes>>,
+    pub data: Vec<PipelineResult<Bytes>>,
 }
 
 impl MockFrameQueueProvider {
     /// Creates a new [MockFrameQueueProvider] with the given data.
-    pub fn new(data: Vec<StageResult<Bytes>>) -> Self {
+    pub fn new(data: Vec<PipelineResult<Bytes>>) -> Self {
         Self { data }
     }
 }
@@ -33,7 +33,7 @@ impl OriginProvider for MockFrameQueueProvider {
 
 #[async_trait]
 impl OriginAdvancer for MockFrameQueueProvider {
-    async fn advance_origin(&mut self) -> StageResult<()> {
+    async fn advance_origin(&mut self) -> PipelineResult<()> {
         Ok(())
     }
 }
@@ -42,14 +42,14 @@ impl OriginAdvancer for MockFrameQueueProvider {
 impl FrameQueueProvider for MockFrameQueueProvider {
     type Item = Bytes;
 
-    async fn next_data(&mut self) -> StageResult<Self::Item> {
-        self.data.pop().unwrap_or(Err(StageError::Eof))
+    async fn next_data(&mut self) -> PipelineResult<Self::Item> {
+        self.data.pop().unwrap_or(Err(PipelineError::Eof.temp()))
     }
 }
 
 #[async_trait]
 impl ResettableStage for MockFrameQueueProvider {
-    async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> StageResult<()> {
+    async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> PipelineResult<()> {
         Ok(())
     }
 }

--- a/crates/derive/src/stages/test_utils/sys_config_fetcher.rs
+++ b/crates/derive/src/stages/test_utils/sys_config_fetcher.rs
@@ -30,6 +30,8 @@ impl MockSystemConfigL2Fetcher {
 
 #[async_trait]
 impl L2ChainProvider for MockSystemConfigL2Fetcher {
+    type Error = anyhow::Error;
+
     async fn system_config_by_number(
         &mut self,
         number: u64,

--- a/crates/derive/src/stages/utils.rs
+++ b/crates/derive/src/stages/utils.rs
@@ -46,7 +46,10 @@ pub fn decompress_brotli(data: &[u8]) -> Result<Vec<u8>, BatchDecompressionError
                 let old_len = output.len();
                 let new_len = old_len * 2;
 
-                ensure!(new_len as u64 <= FJORD_MAX_SPAN_BATCH_BYTES, BatchDecompressionError::BatchTooLarge);
+                ensure!(
+                    new_len as u64 <= FJORD_MAX_SPAN_BATCH_BYTES,
+                    BatchDecompressionError::BatchTooLarge
+                );
 
                 output.resize(new_len, 0);
                 available_out += old_len;

--- a/crates/derive/src/traits/attributes.rs
+++ b/crates/derive/src/traits/attributes.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use op_alloy_protocol::L2BlockInfo;
 use op_alloy_rpc_types_engine::OptimismAttributesWithParent;
 
-use crate::errors::StageResult;
+use crate::errors::PipelineResult;
 
 /// [NextAttributes] defines the interface for pulling attributes from
 /// the top level `AttributesQueue` stage of the pipeline.
@@ -15,5 +15,5 @@ pub trait NextAttributes {
     async fn next_attributes(
         &mut self,
         parent: L2BlockInfo,
-    ) -> StageResult<OptimismAttributesWithParent>;
+    ) -> PipelineResult<OptimismAttributesWithParent>;
 }

--- a/crates/derive/src/traits/data_sources.rs
+++ b/crates/derive/src/traits/data_sources.rs
@@ -1,13 +1,12 @@
 //! Contains traits that describe the functionality of various data sources used in the derivation
 //! pipeline's stages.
 
-use core::fmt::Display;
-
 use crate::errors::PipelineResult;
 use alloc::{boxed::Box, fmt::Debug, vec::Vec};
 use alloy_eips::eip4844::Blob;
 use alloy_primitives::Bytes;
 use async_trait::async_trait;
+use core::fmt::Display;
 use kona_primitives::IndexedBlobHash;
 use op_alloy_protocol::BlockInfo;
 

--- a/crates/derive/src/traits/data_sources.rs
+++ b/crates/derive/src/traits/data_sources.rs
@@ -1,25 +1,28 @@
 //! Contains traits that describe the functionality of various data sources used in the derivation
 //! pipeline's stages.
 
+use core::fmt::Display;
+
 use alloc::{boxed::Box, fmt::Debug, vec::Vec};
 use alloy_eips::eip4844::Blob;
 use alloy_primitives::Bytes;
-use anyhow::Result;
 use async_trait::async_trait;
 use kona_primitives::IndexedBlobHash;
 use op_alloy_protocol::BlockInfo;
-
-use crate::errors::{BlobProviderError, StageResult};
+use crate::errors::PipelineResult;
 
 /// The BlobProvider trait specifies the functionality of a data source that can provide blobs.
 #[async_trait]
 pub trait BlobProvider {
+    /// The error type for the [BlobProvider].
+    type Error: Display;
+
     /// Fetches blobs for a given block ref and the blob hashes.
     async fn get_blobs(
         &mut self,
         block_ref: &BlockInfo,
         blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<Blob>, BlobProviderError>;
+    ) -> Result<Vec<Blob>, Self::Error>;
 }
 
 /// Describes the functionality of a data source that can provide data availability information.
@@ -32,7 +35,7 @@ pub trait DataAvailabilityProvider {
 
     /// Returns the data availability for the block with the given hash, or an error if the block
     /// does not exist in the data source.
-    async fn open_data(&self, block_ref: &BlockInfo) -> Result<Self::DataIter>;
+    async fn open_data(&self, block_ref: &BlockInfo) -> PipelineResult<Self::DataIter>;
 }
 
 /// A simple asynchronous iterator trait.
@@ -44,5 +47,5 @@ pub trait AsyncIterator {
 
     /// Returns the next item in the iterator, or [crate::errors::StageError::Eof] if the iterator
     /// is exhausted.
-    async fn next(&mut self) -> StageResult<Self::Item>;
+    async fn next(&mut self) -> PipelineResult<Self::Item>;
 }

--- a/crates/derive/src/traits/data_sources.rs
+++ b/crates/derive/src/traits/data_sources.rs
@@ -3,13 +3,13 @@
 
 use core::fmt::Display;
 
+use crate::errors::PipelineResult;
 use alloc::{boxed::Box, fmt::Debug, vec::Vec};
 use alloy_eips::eip4844::Blob;
 use alloy_primitives::Bytes;
 use async_trait::async_trait;
 use kona_primitives::IndexedBlobHash;
 use op_alloy_protocol::BlockInfo;
-use crate::errors::PipelineResult;
 
 /// The BlobProvider trait specifies the functionality of a data source that can provide blobs.
 #[async_trait]
@@ -45,7 +45,7 @@ pub trait AsyncIterator {
     /// The item type of the iterator.
     type Item: Send + Sync + Debug + Into<Bytes>;
 
-    /// Returns the next item in the iterator, or [crate::errors::StageError::Eof] if the iterator
-    /// is exhausted.
+    /// Returns the next item in the iterator, or [crate::errors::PipelineError::Eof] if the
+    /// iterator is exhausted.
     async fn next(&mut self) -> PipelineResult<Self::Item>;
 }

--- a/crates/derive/src/traits/pipeline.rs
+++ b/crates/derive/src/traits/pipeline.rs
@@ -6,7 +6,7 @@ use core::iter::Iterator;
 use op_alloy_protocol::{BlockInfo, L2BlockInfo};
 use op_alloy_rpc_types_engine::OptimismAttributesWithParent;
 use super::OriginProvider;
-use crate::errors::StageErrorKind;
+use crate::errors::{PipelineResult, StageErrorKind};
 
 /// A pipeline error.
 #[derive(Debug)]
@@ -28,7 +28,7 @@ pub trait Pipeline: OriginProvider + Iterator<Item = OptimismAttributesWithParen
     fn peek(&self) -> Option<&OptimismAttributesWithParent>;
 
     /// Resets the pipeline on the next [Pipeline::step] call.
-    async fn reset(&mut self, l2_block_info: BlockInfo, origin: BlockInfo) -> anyhow::Result<()>;
+    async fn reset(&mut self, l2_block_info: BlockInfo, origin: BlockInfo) -> PipelineResult<()>;
 
     /// Attempts to progress the pipeline.
     async fn step(&mut self, cursor: L2BlockInfo) -> StepResult;

--- a/crates/derive/src/traits/pipeline.rs
+++ b/crates/derive/src/traits/pipeline.rs
@@ -5,9 +5,8 @@ use async_trait::async_trait;
 use core::iter::Iterator;
 use op_alloy_protocol::{BlockInfo, L2BlockInfo};
 use op_alloy_rpc_types_engine::OptimismAttributesWithParent;
-
 use super::OriginProvider;
-use crate::errors::StageError;
+use crate::errors::StageErrorKind;
 
 /// A pipeline error.
 #[derive(Debug)]
@@ -17,9 +16,9 @@ pub enum StepResult {
     /// Origin was advanced.
     AdvancedOrigin,
     /// Origin advance failed.
-    OriginAdvanceErr(StageError),
+    OriginAdvanceErr(StageErrorKind),
     /// Step failed.
-    StepFailed(StageError),
+    StepFailed(StageErrorKind),
 }
 
 /// This trait defines the interface for interacting with the derivation pipeline.

--- a/crates/derive/src/traits/pipeline.rs
+++ b/crates/derive/src/traits/pipeline.rs
@@ -1,7 +1,7 @@
 //! Defines the interface for the core derivation pipeline.
 
 use super::OriginProvider;
-use crate::errors::{PipelineResult, StageErrorKind};
+use crate::errors::{PipelineErrorKind, PipelineResult};
 use alloc::boxed::Box;
 use async_trait::async_trait;
 use core::iter::Iterator;
@@ -16,9 +16,9 @@ pub enum StepResult {
     /// Origin was advanced.
     AdvancedOrigin,
     /// Origin advance failed.
-    OriginAdvanceErr(StageErrorKind),
+    OriginAdvanceErr(PipelineErrorKind),
     /// Step failed.
-    StepFailed(StageErrorKind),
+    StepFailed(PipelineErrorKind),
 }
 
 /// This trait defines the interface for interacting with the derivation pipeline.

--- a/crates/derive/src/traits/pipeline.rs
+++ b/crates/derive/src/traits/pipeline.rs
@@ -1,12 +1,12 @@
 //! Defines the interface for the core derivation pipeline.
 
+use super::OriginProvider;
+use crate::errors::{PipelineResult, StageErrorKind};
 use alloc::boxed::Box;
 use async_trait::async_trait;
 use core::iter::Iterator;
 use op_alloy_protocol::{BlockInfo, L2BlockInfo};
 use op_alloy_rpc_types_engine::OptimismAttributesWithParent;
-use super::OriginProvider;
-use crate::errors::{PipelineResult, StageErrorKind};
 
 /// A pipeline error.
 #[derive(Debug)]

--- a/crates/derive/src/traits/providers.rs
+++ b/crates/derive/src/traits/providers.rs
@@ -1,6 +1,6 @@
 use core::fmt::Display;
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec, string::ToString};
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_primitives::B256;
 use async_trait::async_trait;
@@ -12,7 +12,7 @@ use op_alloy_protocol::{BlockInfo, L2BlockInfo};
 #[async_trait]
 pub trait ChainProvider {
     /// The error type for the [ChainProvider].
-    type Error: Display;
+    type Error: Display + ToString;
 
     /// Fetch the L1 [Header] for the given [B256] hash.
     async fn header_by_hash(&mut self, hash: B256) -> Result<Header, Self::Error>;
@@ -36,7 +36,7 @@ pub trait ChainProvider {
 #[async_trait]
 pub trait L2ChainProvider {
     /// The error type for the [L2ChainProvider].
-    type Error: Display;
+    type Error: Display + ToString;
 
     /// Returns the L2 block info given a block number.
     /// Errors if the block does not exist.

--- a/crates/derive/src/traits/providers.rs
+++ b/crates/derive/src/traits/providers.rs
@@ -1,7 +1,8 @@
+use core::fmt::Display;
+
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_primitives::B256;
-use anyhow::Result;
 use async_trait::async_trait;
 use kona_primitives::L2ExecutionPayloadEnvelope;
 use op_alloy_genesis::{RollupConfig, SystemConfig};
@@ -10,39 +11,45 @@ use op_alloy_protocol::{BlockInfo, L2BlockInfo};
 /// Describes the functionality of a data source that can provide information from the blockchain.
 #[async_trait]
 pub trait ChainProvider {
+    /// The error type for the [ChainProvider].
+    type Error: Display;
+
     /// Fetch the L1 [Header] for the given [B256] hash.
-    async fn header_by_hash(&mut self, hash: B256) -> Result<Header>;
+    async fn header_by_hash(&mut self, hash: B256) -> Result<Header, Self::Error>;
 
     /// Returns the block at the given number, or an error if the block does not exist in the data
     /// source.
-    async fn block_info_by_number(&mut self, number: u64) -> Result<BlockInfo>;
+    async fn block_info_by_number(&mut self, number: u64) -> Result<BlockInfo, Self::Error>;
 
     /// Returns all receipts in the block with the given hash, or an error if the block does not
     /// exist in the data source.
-    async fn receipts_by_hash(&mut self, hash: B256) -> Result<Vec<Receipt>>;
+    async fn receipts_by_hash(&mut self, hash: B256) -> Result<Vec<Receipt>, Self::Error>;
 
     /// Returns the [BlockInfo] and list of [TxEnvelope]s from the given block hash.
     async fn block_info_and_transactions_by_hash(
         &mut self,
         hash: B256,
-    ) -> Result<(BlockInfo, Vec<TxEnvelope>)>;
+    ) -> Result<(BlockInfo, Vec<TxEnvelope>), Self::Error>;
 }
 
 /// Describes the functionality of a data source that fetches safe blocks.
 #[async_trait]
 pub trait L2ChainProvider {
+    /// The error type for the [L2ChainProvider].
+    type Error: Display;
+
     /// Returns the L2 block info given a block number.
     /// Errors if the block does not exist.
-    async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo>;
+    async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo, Self::Error>;
 
     /// Returns an execution payload for a given number.
     /// Errors if the execution payload does not exist.
-    async fn payload_by_number(&mut self, number: u64) -> Result<L2ExecutionPayloadEnvelope>;
+    async fn payload_by_number(&mut self, number: u64) -> Result<L2ExecutionPayloadEnvelope, Self::Error>;
 
     /// Returns the [SystemConfig] by L2 number.
     async fn system_config_by_number(
         &mut self,
         number: u64,
         rollup_config: Arc<RollupConfig>,
-    ) -> Result<SystemConfig>;
+    ) -> Result<SystemConfig, Self::Error>;
 }

--- a/crates/derive/src/traits/providers.rs
+++ b/crates/derive/src/traits/providers.rs
@@ -1,6 +1,6 @@
 use core::fmt::Display;
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec, string::ToString};
+use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_primitives::B256;
 use async_trait::async_trait;
@@ -44,7 +44,10 @@ pub trait L2ChainProvider {
 
     /// Returns an execution payload for a given number.
     /// Errors if the execution payload does not exist.
-    async fn payload_by_number(&mut self, number: u64) -> Result<L2ExecutionPayloadEnvelope, Self::Error>;
+    async fn payload_by_number(
+        &mut self,
+        number: u64,
+    ) -> Result<L2ExecutionPayloadEnvelope, Self::Error>;
 
     /// Returns the [SystemConfig] by L2 number.
     async fn system_config_by_number(

--- a/crates/derive/src/traits/stages.rs
+++ b/crates/derive/src/traits/stages.rs
@@ -5,13 +5,13 @@ use async_trait::async_trait;
 use op_alloy_genesis::SystemConfig;
 use op_alloy_protocol::BlockInfo;
 
-use crate::errors::StageResult;
+use crate::errors::PipelineResult;
 
 /// Describes the functionality fo a resettable stage within the derivation pipeline.
 #[async_trait]
 pub trait ResettableStage {
     /// Resets the derivation stage to its initial state.
-    async fn reset(&mut self, base: BlockInfo, cfg: &SystemConfig) -> StageResult<()>;
+    async fn reset(&mut self, base: BlockInfo, cfg: &SystemConfig) -> PipelineResult<()>;
 }
 
 /// Provides a method for accessing the pipeline's current L1 origin.
@@ -25,5 +25,5 @@ pub trait OriginProvider {
 pub trait OriginAdvancer {
     /// Advances the internal state of the lowest stage to the next l1 origin.
     /// This method is the equivalent of the reference implementation `advance_l1_block`.
-    async fn advance_origin(&mut self) -> StageResult<()>;
+    async fn advance_origin(&mut self) -> PipelineResult<()>;
 }

--- a/crates/derive/src/traits/test_utils.rs
+++ b/crates/derive/src/traits/test_utils.rs
@@ -1,5 +1,11 @@
 //! Test Utilities for derive traits
 
+use crate::{
+    errors::{BlobProviderError, PipelineError, PipelineResult},
+    traits::{
+        AsyncIterator, BlobProvider, ChainProvider, DataAvailabilityProvider, L2ChainProvider,
+    },
+};
 use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_eips::eip4844::Blob;
@@ -11,12 +17,6 @@ use hashbrown::HashMap;
 use kona_primitives::{IndexedBlobHash, L2ExecutionPayloadEnvelope};
 use op_alloy_genesis::{RollupConfig, SystemConfig};
 use op_alloy_protocol::{BlockInfo, L2BlockInfo};
-use crate::{
-    errors::{BlobProviderError, PipelineError, PipelineResult},
-    traits::{
-        AsyncIterator, BlobProvider, ChainProvider, DataAvailabilityProvider, L2ChainProvider,
-    },
-};
 
 /// Mock data iterator
 #[derive(Debug, Default, PartialEq)]

--- a/crates/derive/src/traits/test_utils.rs
+++ b/crates/derive/src/traits/test_utils.rs
@@ -11,7 +11,6 @@ use hashbrown::HashMap;
 use kona_primitives::{IndexedBlobHash, L2ExecutionPayloadEnvelope};
 use op_alloy_genesis::{RollupConfig, SystemConfig};
 use op_alloy_protocol::{BlockInfo, L2BlockInfo};
-
 use crate::{
     errors::{BlobProviderError, PipelineError, PipelineResult},
     traits::{

--- a/crates/derive/src/traits/test_utils.rs
+++ b/crates/derive/src/traits/test_utils.rs
@@ -13,7 +13,7 @@ use op_alloy_genesis::{RollupConfig, SystemConfig};
 use op_alloy_protocol::{BlockInfo, L2BlockInfo};
 
 use crate::{
-    errors::{BlobProviderError, StageError, StageResult},
+    errors::{BlobProviderError, PipelineError, PipelineResult},
     traits::{
         AsyncIterator, BlobProvider, ChainProvider, DataAvailabilityProvider, L2ChainProvider,
     },
@@ -25,15 +25,15 @@ pub struct TestIter {
     /// Holds open data calls with args for assertions.
     pub(crate) open_data_calls: Vec<(BlockInfo, Address)>,
     /// A queue of results to return as the next iterated data.
-    pub(crate) results: Vec<StageResult<Bytes>>,
+    pub(crate) results: Vec<PipelineResult<Bytes>>,
 }
 
 #[async_trait]
 impl AsyncIterator for TestIter {
     type Item = Bytes;
 
-    async fn next(&mut self) -> StageResult<Self::Item> {
-        self.results.pop().unwrap_or_else(|| Err(StageError::Eof))
+    async fn next(&mut self) -> PipelineResult<Self::Item> {
+        self.results.pop().unwrap_or(Err(PipelineError::Eof.temp()))
     }
 }
 
@@ -43,7 +43,7 @@ pub struct TestDAP {
     /// The batch inbox address.
     pub batch_inbox_address: Address,
     /// Specifies the stage results the test iter returns as data.
-    pub(crate) results: Vec<StageResult<Bytes>>,
+    pub(crate) results: Vec<PipelineResult<Bytes>>,
 }
 
 #[async_trait]
@@ -51,16 +51,16 @@ impl DataAvailabilityProvider for TestDAP {
     type Item = Bytes;
     type DataIter = TestIter;
 
-    async fn open_data(&self, block_ref: &BlockInfo) -> Result<Self::DataIter> {
+    async fn open_data(&self, block_ref: &BlockInfo) -> PipelineResult<Self::DataIter> {
         // Construct a new vec of results to return.
         let results = self
             .results
             .iter()
             .map(|i| match i {
                 Ok(r) => Ok(r.clone()),
-                Err(_) => Err(StageError::Eof),
+                Err(_) => Err(PipelineError::Eof.temp()),
             })
-            .collect::<Vec<StageResult<Bytes>>>();
+            .collect::<Vec<PipelineResult<Bytes>>>();
         Ok(TestIter { open_data_calls: vec![(*block_ref, self.batch_inbox_address)], results })
     }
 }
@@ -130,6 +130,8 @@ impl TestChainProvider {
 
 #[async_trait]
 impl ChainProvider for TestChainProvider {
+    type Error = anyhow::Error;
+
     async fn header_by_hash(&mut self, hash: B256) -> Result<Header> {
         if let Some((_, header)) = self.headers.iter().find(|(_, b)| b.hash_slow() == hash) {
             Ok(header.clone())
@@ -195,11 +197,13 @@ impl TestBlobProvider {
 
 #[async_trait]
 impl BlobProvider for TestBlobProvider {
+    type Error = BlobProviderError;
+
     async fn get_blobs(
         &mut self,
         _block_ref: &BlockInfo,
         blob_hashes: &[IndexedBlobHash],
-    ) -> Result<Vec<Blob>, BlobProviderError> {
+    ) -> Result<Vec<Blob>, Self::Error> {
         let mut blobs = Vec::new();
         for blob_hash in blob_hashes {
             if let Some(data) = self.blobs.get(&blob_hash.hash) {
@@ -236,6 +240,8 @@ impl TestL2ChainProvider {
 
 #[async_trait]
 impl L2ChainProvider for TestL2ChainProvider {
+    type Error = anyhow::Error;
+
     async fn l2_block_info_by_number(&mut self, number: u64) -> Result<L2BlockInfo> {
         if self.short_circuit {
             return self.blocks.first().copied().ok_or_else(|| anyhow::anyhow!("Block not found"));

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -11,6 +11,7 @@ homepage.workspace = true
 [dependencies]
 # General
 anyhow.workspace = true
+thiserror.workspace = true
 
 # Alloy
 alloy-eips.workspace = true

--- a/crates/primitives/src/blob.rs
+++ b/crates/primitives/src/blob.rs
@@ -3,7 +3,7 @@
 use alloc::vec;
 use alloy_eips::eip4844::{Blob, BYTES_PER_BLOB, VERSIONED_HASH_VERSION_KZG};
 use alloy_primitives::{Bytes, B256};
-use anyhow::Result;
+use thiserror::Error;
 
 /// The blob encoding version
 pub(crate) const BLOB_ENCODING_VERSION: u8 = 0;
@@ -31,15 +31,19 @@ impl PartialEq for IndexedBlobHash {
 }
 
 /// Blob Decuding Error
-#[derive(Debug)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum BlobDecodingError {
     /// Invalid field element
+    #[error("Invalid field element")]
     InvalidFieldElement,
     /// Invalid encoding version
+    #[error("Invalid encoding version")]
     InvalidEncodingVersion,
     /// Invalid length
+    #[error("Invalid length")]
     InvalidLength,
     /// Missing Data
+    #[error("Missing data")]
     MissingData,
 }
 
@@ -171,18 +175,18 @@ impl BlobData {
     /// Fills in the pointers to the fetched blob bodies.
     /// There should be exactly one placeholder blobOrCalldata
     /// element for each blob, otherwise an error is returned.
-    pub fn fill(&mut self, blobs: &[Blob], index: usize) -> Result<()> {
+    pub fn fill(&mut self, blobs: &[Blob], index: usize) -> Result<(), BlobDecodingError> {
         // Do not fill if there is no calldata to fill
         if self.calldata.as_ref().map_or(false, |data| data.is_empty()) {
             return Ok(());
         }
 
         if index >= blobs.len() {
-            return Err(anyhow::anyhow!("Insufficient blob count"));
+            return Err(BlobDecodingError::InvalidLength);
         }
 
         if blobs[index].is_empty() {
-            return Err(anyhow::anyhow!("Empty blob"));
+            return Err(BlobDecodingError::MissingData);
         }
 
         self.data = Some(Bytes::from(blobs[index]));

--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -1,6 +1,9 @@
 use anyhow::Result;
 use clap::Parser;
-use kona_derive::{errors::{PipelineError, StageErrorKind}, online::*};
+use kona_derive::{
+    errors::{PipelineError, StageErrorKind},
+    online::*,
+};
 use std::sync::Arc;
 use superchain::ROLLUP_CONFIGS;
 use tracing::{debug, error, info, trace, warn};
@@ -152,8 +155,8 @@ async fn sync(cli: cli::Cli) -> Result<()> {
                             error!(target: LOG_TARGET, "Failed to get block info by number: {}", latest - 100);
                             continue;
                         }
-                    } else if drift > cli.drift_threshold as i64
-                        && timestamp as i64 > metrics::DRIFT_WALKBACK_TIMESTAMP.get() + 300
+                    } else if drift > cli.drift_threshold as i64 &&
+                        timestamp as i64 > metrics::DRIFT_WALKBACK_TIMESTAMP.get() + 300
                     {
                         metrics::DRIFT_WALKBACK.set(cursor.block_info.number as i64);
                         metrics::DRIFT_WALKBACK_TIMESTAMP.set(timestamp as i64);

--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use kona_derive::{
-    errors::{PipelineError, StageErrorKind},
+    errors::{PipelineError, PipelineErrorKind},
     online::*,
 };
 use std::sync::Arc;
@@ -219,7 +219,7 @@ async fn sync(cli: cli::Cli) -> Result<()> {
                 warn!(target: "loop", "Could not advance origin: {:?}", e);
             }
             StepResult::StepFailed(e) => match e {
-                StageErrorKind::Temporary(e) => {
+                PipelineErrorKind::Temporary(e) => {
                     if matches!(e, PipelineError::NotEnoughData) {
                         metrics::PIPELINE_STEPS.with_label_values(&["not_enough_data"]).inc();
                         debug!(target: "loop", "Not enough data to step derivation pipeline");

--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -225,7 +225,16 @@ async fn sync(cli: cli::Cli) -> Result<()> {
                         debug!(target: "loop", "Not enough data to step derivation pipeline");
                     }
                 }
-                // TODO: RESET
+                PipelineErrorKind::Reset(_) => {
+                    metrics::PIPELINE_STEPS.with_label_values(&["reset"]).inc();
+                    warn!(target: "loop", "Resetting pipeline: {:?}", e);
+                    pipeline
+                        .reset(
+                            cursor.block_info,
+                            pipeline.origin().ok_or(anyhow::anyhow!("Missing origin"))?,
+                        )
+                        .await?;
+                }
                 _ => {
                     metrics::PIPELINE_STEPS.with_label_values(&["failure"]).inc();
                     error!(target: "loop", "Error stepping derivation pipeline: {:?}", e);

--- a/examples/trusted-sync/src/main.rs
+++ b/examples/trusted-sync/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use kona_derive::{errors::StageError, online::*};
+use kona_derive::{errors::{PipelineError, StageErrorKind}, online::*};
 use std::sync::Arc;
 use superchain::ROLLUP_CONFIGS;
 use tracing::{debug, error, info, trace, warn};
@@ -152,8 +152,8 @@ async fn sync(cli: cli::Cli) -> Result<()> {
                             error!(target: LOG_TARGET, "Failed to get block info by number: {}", latest - 100);
                             continue;
                         }
-                    } else if drift > cli.drift_threshold as i64 &&
-                        timestamp as i64 > metrics::DRIFT_WALKBACK_TIMESTAMP.get() + 300
+                    } else if drift > cli.drift_threshold as i64
+                        && timestamp as i64 > metrics::DRIFT_WALKBACK_TIMESTAMP.get() + 300
                     {
                         metrics::DRIFT_WALKBACK.set(cursor.block_info.number as i64);
                         metrics::DRIFT_WALKBACK_TIMESTAMP.set(timestamp as i64);
@@ -216,10 +216,13 @@ async fn sync(cli: cli::Cli) -> Result<()> {
                 warn!(target: "loop", "Could not advance origin: {:?}", e);
             }
             StepResult::StepFailed(e) => match e {
-                StageError::NotEnoughData => {
-                    metrics::PIPELINE_STEPS.with_label_values(&["not_enough_data"]).inc();
-                    debug!(target: "loop", "Not enough data to step derivation pipeline");
+                StageErrorKind::Temporary(e) => {
+                    if matches!(e, PipelineError::NotEnoughData) {
+                        metrics::PIPELINE_STEPS.with_label_values(&["not_enough_data"]).inc();
+                        debug!(target: "loop", "Not enough data to step derivation pipeline");
+                    }
                 }
+                // TODO: RESET
                 _ => {
                     metrics::PIPELINE_STEPS.with_label_values(&["failure"]).inc();
                     error!(target: "loop", "Error stepping derivation pipeline: {:?}", e);


### PR DESCRIPTION
## Overview

The first of a few PRs, migrates `kona-derive` over to typed errors in order to better be able to distinguish temporary, reset, and critical errors on the end of the consumer.
