### PR TITLE
chore(workspace): Bump MSRV to `1.81`

### DIFF
--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -73,5 +73,4 @@ jobs:
             $L2_OUTPUT_ROOT \
             $L2_HEAD \
             $L1_HEAD \
-            $L2_CHAIN_ID \
-            -vv
+            $L2_CHAIN_ID

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 version = "0.0.0"
 edition = "2021"
 license = "MIT"
-rust-version = "1.80"
+rust-version = "1.81"
 authors = ["clabby", "refcell"]
 repository = "https://github.com/anton-rs/kona"
 homepage = "https://github.com/anton-rs/kona"

--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -5,7 +5,7 @@ default:
   @just --list
 
 # Run the client program on asterisc with the host in detached server mode.
-run-client-asterisc block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbosity:
+run-client-asterisc block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbosity='':
   #!/usr/bin/env bash
 
   L1_NODE_ADDRESS="{{l1_rpc}}"
@@ -63,7 +63,7 @@ run-client-asterisc block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc ver
     {{verbosity}}
 
 # Run the client program natively with the host program attached.
-run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbosity:
+run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbosity='':
   #!/usr/bin/env bash
 
   L1_NODE_ADDRESS="{{l1_rpc}}"
@@ -107,7 +107,7 @@ run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbo
     {{verbosity}}
 
 # Run the client program natively with the host program attached, in offline mode.
-run-client-native-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id verbosity:
+run-client-native-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id verbosity='':
   #!/usr/bin/env bash
 
   CLIENT_BIN_PATH="./target/release-client-lto/kona"
@@ -137,7 +137,7 @@ run-client-native-offline block_number l2_claim l2_output_root l2_head l1_head l
     {{verbosity}}
 
 # Run the client program on asterisc with the host program detached, in offline mode.
-run-client-asterisc-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id verbosity:
+run-client-asterisc-offline block_number l2_claim l2_output_root l2_head l1_head l2_chain_id verbosity='':
   #!/usr/bin/env bash
 
   HOST_BIN_PATH="./target/release/kona-host"


### PR DESCRIPTION
## Overview

Bumps the MSRV to `1.81`, as we now rely on `core::error::Error`
