### PR TITLE
chore(workspace): Allow stdlib in `cfg(test)`

### DIFF
--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -58,8 +58,6 @@ pub fn exit(code: usize) -> ! {
 
 #[cfg(not(any(target_arch = "mips", target_arch = "riscv64", target_os = "zkvm")))]
 mod native_io {
-    extern crate std;
-
     use crate::{
         errors::{IOError, IOResult},
         io::FileDescriptor,

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(target_arch = "mips", feature(asm_experimental_arch))]
-#![no_std]
+#![cfg_attr(any(target_arch = "mips", target_arch = "riscv64", target_os = "zkvm"), no_std)]
 
 extern crate alloc;
 

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 extern crate alloc;
 
@@ -646,8 +646,6 @@ where
 
 #[cfg(test)]
 mod test {
-    extern crate std;
-
     use super::*;
     use alloy_primitives::{address, b256, hex};
     use alloy_rlp::Decodable;
@@ -656,7 +654,7 @@ mod test {
     use kona_mpt::NoopTrieHinter;
     use op_alloy_genesis::{OP_BASE_FEE_PARAMS, OP_CANYON_BASE_FEE_PARAMS};
     use serde::Deserialize;
-    use std::{collections::HashMap, format};
+    use std::collections::HashMap;
 
     /// A [TrieProvider] implementation that fetches trie nodes and bytecode from the local
     /// testdata folder.

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 extern crate alloc;
 

--- a/crates/mpt/src/test_util.rs
+++ b/crates/mpt/src/test_util.rs
@@ -1,8 +1,6 @@
 //! Testing utilities for `kona-mpt`
 
-extern crate std;
-
-use crate::{ordered_trie_with_encoder, TrieProvider};
+use crate::{ordered_trie_with_encoder, TrieDBFetcher};
 use alloc::{collections::BTreeMap, vec::Vec};
 use alloy_consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom, TxEnvelope, TxType};
 use alloy_primitives::{keccak256, Bytes, Log, B256};

--- a/crates/mpt/src/test_util.rs
+++ b/crates/mpt/src/test_util.rs
@@ -1,6 +1,6 @@
 //! Testing utilities for `kona-mpt`
 
-use crate::{ordered_trie_with_encoder, TrieDBFetcher};
+use crate::{ordered_trie_with_encoder, TrieProvider};
 use alloc::{collections::BTreeMap, vec::Vec};
 use alloy_consensus::{Receipt, ReceiptEnvelope, ReceiptWithBloom, TxEnvelope, TxType};
 use alloy_primitives::{keccak256, Bytes, Log, B256};

--- a/crates/preimage/src/hint.rs
+++ b/crates/preimage/src/hint.rs
@@ -111,8 +111,6 @@ impl HintReaderServer for HintReader {
 
 #[cfg(test)]
 mod test {
-    extern crate std;
-
     use super::*;
     use crate::test_utils::bidirectional_pipe;
     use alloc::{string::ToString, sync::Arc, vec::Vec};

--- a/crates/preimage/src/lib.rs
+++ b/crates/preimage/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 extern crate alloc;
 

--- a/crates/preimage/src/oracle.rs
+++ b/crates/preimage/src/oracle.rs
@@ -130,8 +130,6 @@ impl PreimageOracleServer for OracleServer {
 
 #[cfg(test)]
 mod test {
-    extern crate std;
-
     use super::*;
     use crate::{test_utils::bidirectional_pipe, PreimageKeyType};
     use alloc::sync::Arc;

--- a/crates/preimage/src/test_utils.rs
+++ b/crates/preimage/src/test_utils.rs
@@ -1,7 +1,5 @@
 //! Test utilities for the `kona-preimage` crate.
 
-extern crate std;
-
 use os_pipe::{PipeReader, PipeWriter};
 use std::io::Result;
 


### PR DESCRIPTION
## Overview

Allows use of `std` in `cfg(test)` without the use of `extern crate std`.
