### PR TITLE
chore(workspace): Bump dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash 0.8.11",
+ "ahash",
  "base64",
  "bitflags 2.6.0",
  "brotli",
@@ -146,7 +146,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "ahash 0.8.11",
+ "ahash",
  "bytes",
  "bytestring",
  "cfg-if",
@@ -202,17 +202,6 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
@@ -256,9 +245,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.31"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68b94c159bcc2ca5f758b8663d7b00fc7c5e40569984595ddf2221b0f7f7f6e"
+checksum = "805f7a974de5804f5c053edc6ca43b20883bdd3a733b3691200ae3a4b454a2db"
 dependencies = [
  "num_enum",
  "strum",
@@ -340,7 +329,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.64",
  "tracing",
 ]
 
@@ -362,7 +351,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
- "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -389,7 +378,7 @@ dependencies = [
  "rand",
  "serde_json",
  "tempfile",
- "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.64",
  "tracing",
  "url",
 ]
@@ -444,7 +433,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.64",
  "tokio",
  "tracing",
  "url",
@@ -534,7 +523,7 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "derive_more 1.0.0",
- "hashbrown 0.14.5",
+ "hashbrown",
  "itertools 0.13.0",
  "serde",
  "serde_json",
@@ -562,7 +551,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -635,7 +624,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.64",
  "tokio",
  "tower 0.5.1",
  "tracing",
@@ -666,7 +655,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "derive_more 1.0.0",
- "hashbrown 0.14.5",
+ "hashbrown",
  "nybbles",
  "smallvec",
  "tracing",
@@ -1077,24 +1066,25 @@ checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.12"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+checksum = "50c8f430744b23b54ad15161fcbc22d82a29b73eacbe425fea23ec822600bc6f"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
+ "rancor",
  "simdutf8",
 ]
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.12"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+checksum = "523363cbe1df49b68215efdf500b103ac3b0fb4836aed6d15689a076eadb8fff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1225,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b0956a43b323ac1afaffc053ed5c4b7c1f1800bacd1683c353aabbb752515dd3"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1235,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "4d72166dd41634086d5803a47eb71ae740e61d84709c36f3c34110173db3961b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1247,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1276,7 +1266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb11bd1378bf3731b182997b40cefe00aba6a6cc74042c8318c1b271d3badf7"
 dependencies = [
  "nix 0.27.1",
- "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.64",
  "tokio",
 ]
 
@@ -1456,7 +1446,7 @@ checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
- "hashbrown 0.14.5",
+ "hashbrown",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1930,20 +1920,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "allocator-api2",
  "serde",
 ]
@@ -2163,7 +2144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2172,7 +2153,7 @@ version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "indexmap",
  "is-terminal",
  "itoa",
@@ -2260,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -2319,7 +2300,7 @@ version = "0.0.3"
 dependencies = [
  "cfg-if",
  "linked_list_allocator",
- "thiserror 1.0.63 (git+https://github.com/quartiq/thiserror?branch=no-std)",
+ "thiserror 1.0.63",
 ]
 
 [[package]]
@@ -2352,7 +2333,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "brotli",
- "hashbrown 0.14.5",
+ "hashbrown",
  "kona-primitives",
  "lazy_static",
  "lru",
@@ -2367,7 +2348,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin",
- "thiserror 1.0.63 (git+https://github.com/quartiq/thiserror?branch=no-std)",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2394,7 +2375,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 1.0.63 (git+https://github.com/quartiq/thiserror?branch=no-std)",
+ "thiserror 1.0.63",
  "tracing",
 ]
 
@@ -2454,7 +2435,7 @@ dependencies = [
  "rand",
  "reqwest",
  "revm",
- "thiserror 1.0.63 (git+https://github.com/quartiq/thiserror?branch=no-std)",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2470,7 +2451,7 @@ dependencies = [
  "os_pipe",
  "rkyv",
  "serde",
- "thiserror 1.0.63 (git+https://github.com/quartiq/thiserror?branch=no-std)",
+ "thiserror 1.0.63",
  "tokio",
  "tracing",
 ]
@@ -2492,7 +2473,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror 1.0.63 (git+https://github.com/quartiq/thiserror?branch=no-std)",
+ "thiserror 1.0.63",
  "tracing",
 ]
 
@@ -2628,7 +2609,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ee39891760e7d94734f6f63fedc29a2e4a152f836120753a72503f09fcf904"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2678,6 +2659,26 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64142d38c84badf60abf06ff9bd80ad2174306a5b11bd4706535090a30a419df"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bb5c1d8184f13f7d0ccbeeca0def2f9a181bce2624302793005f5ca8aa62e5e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2931,7 +2932,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "hashbrown 0.14.5",
+ "hashbrown",
  "op-alloy-consensus",
  "op-alloy-genesis",
  "serde",
@@ -3089,12 +3090,12 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
- "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.64",
  "ucd-trie",
 ]
 
@@ -3199,7 +3200,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -3308,7 +3309,7 @@ dependencies = [
  "parking_lot",
  "procfs",
  "protobuf",
- "thiserror 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -3371,22 +3372,22 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"
-version = "0.1.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
 dependencies = [
  "ptr_meta_derive",
 ]
 
 [[package]]
 name = "ptr_meta_derive"
-version = "0.1.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3418,6 +3419,15 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rancor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -3524,9 +3534,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rend"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+checksum = "a31c1f1959e4db12c985c0283656be0925f1539549db1e47c4bd0b8b599e1ef7"
 dependencies = [
  "bytecheck",
 ]
@@ -3634,7 +3644,7 @@ dependencies = [
  "cfg-if",
  "dyn-clone",
  "enumn",
- "hashbrown 0.14.5",
+ "hashbrown",
  "hex",
  "serde",
 ]
@@ -3684,31 +3694,32 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.45"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+checksum = "395027076c569819ea6035ee62e664f5e03d74e281744f55261dd1afd939212b"
 dependencies = [
- "bitvec",
  "bytecheck",
  "bytes",
- "hashbrown 0.12.3",
+ "hashbrown",
+ "indexmap",
+ "munge",
  "ptr_meta",
+ "rancor",
  "rend",
  "rkyv_derive",
- "seahash",
  "tinyvec",
  "uuid",
 ]
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.45"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+checksum = "09cb82b74b4810f07e460852c32f522e979787691b0b7b7439fe473e49d49b2f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -3899,12 +3910,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3952,9 +3957,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4108,9 +4113,9 @@ dependencies = [
 
 [[package]]
 name = "simdutf8"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -4238,12 +4243,12 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superchain"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9113b97b12c98b213c77646077ef98f2b1f110e60a3f1b7813f46fb880e28d"
+checksum = "c2e6a2cf2036fe8d041cc4efa8b1a91660b77497077b1656ab769e8665d8ad0c"
 dependencies = [
  "alloy-primitives",
- "hashbrown 0.14.5",
+ "hashbrown",
  "lazy_static",
  "op-alloy-genesis",
  "serde",
@@ -4365,25 +4370,24 @@ dependencies = [
 [[package]]
 name = "thiserror"
 version = "1.0.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+source = "git+https://github.com/quartiq/thiserror?branch=no-std#44737a516b7fd0cc9dabcab07e7b1f927f8f5636"
 dependencies = [
- "thiserror-impl 1.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror-impl 1.0.63",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
-source = "git+https://github.com/quartiq/thiserror?branch=no-std#44737a516b7fd0cc9dabcab07e7b1f927f8f5636"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
- "thiserror-impl 1.0.63 (git+https://github.com/quartiq/thiserror?branch=no-std)",
+ "thiserror-impl 1.0.64",
 ]
 
 [[package]]
 name = "thiserror-impl"
 version = "1.0.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+source = "git+https://github.com/quartiq/thiserror?branch=no-std#44737a516b7fd0cc9dabcab07e7b1f927f8f5636"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4392,8 +4396,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
-source = "git+https://github.com/quartiq/thiserror?branch=no-std#44737a516b7fd0cc9dabcab07e7b1f927f8f5636"
+version = "1.0.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4803,9 +4808,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229730647fbc343e3a80e463c1db7f78f3855d3f3739bee0dda773c9a037c90a"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsigned-varint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,22 +47,22 @@ kona-derive = { path = "crates/derive", version = "0.0.3", default-features = fa
 kona-primitives = { path = "crates/primitives", version = "0.0.2", default-features = false }
 
 # General
-anyhow = { version = "1.0.86", default-features = false }
+anyhow = { version = "1.0.89", default-features = false }
 thiserror = { git = "https://github.com/quartiq/thiserror", branch = "no-std", default-features = false }
 cfg-if = "1.0.0"
 hashbrown = "0.14.5"
 spin = { version = "0.9.8", features = ["mutex"] }
-lru = "0.12.3"
-async-trait = "0.1.80"
+lru = "0.12.4"
+async-trait = "0.1.82"
 lazy_static = "1.5.0"
 reqwest = "0.12"
 os_pipe = "1.2.1"
-actix-web = "4.8.0"
+actix-web = "4.9.0"
 rand = "0.8.5"
 futures = { version = "0.3.30", default-features = false }
 prometheus = { version = "0.13.4", features = ["process"] }
-tokio = { version = "1.38", features = ["full"] }
-clap = { version = "4.5.4", features = ["derive", "env"] }
+tokio = { version = "1.40", features = ["full"] }
+clap = { version = "4.5.18", features = ["derive", "env"] }
 sha2 = { version = "0.10.8", default-features = false }
 c-kzg = { version = "1.0.2", default-features = false }
 alloc-no-stdlib = "2.0.4"
@@ -79,18 +79,18 @@ miniz_oxide = "0.8.0"
 brotli = { version = "6.0.0", default-features = false }
 
 # Testing
-proptest = "1.4"
+proptest = "1.5"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 pprof = { version = "0.13.0", features = ["criterion", "flamegraph", "frame-pointer"] } 
 
 # Serialization
-rkyv = "0.7.44"
-serde = { version = "1.0.203", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0.125", default-features = false }
+rkyv = "0.8.8"
+serde = { version = "1.0.210", default-features = false, features = ["derive"] }
+serde_json = { version = "1.0.128", default-features = false }
 
 # Ethereum
 unsigned-varint = "0.8.0"
-revm = { version = "14.0", default-features = false }
+revm = { version = "14.0.2", default-features = false }
 
 # Optimism
 superchain = { version = "0.5", default-features = false }
@@ -100,17 +100,17 @@ rocksdb = { version = "0.22", default-features = false, features = ["snappy"] }
 
 # Alloy
 alloy-rlp = { version = "0.3.8", default-features = false }
-alloy-trie = { version = "0.5", default-features = false }
-alloy-eips = { version = "0.3.5", default-features = false }
-alloy-provider = { version = "0.3.5", default-features = false }
+alloy-trie = { version = "0.5.3", default-features = false }
+alloy-eips = { version = "0.3.6", default-features = false }
+alloy-provider = { version = "0.3.6", default-features = false }
 alloy-primitives = { version = "0.8", default-features = false }
-alloy-consensus = { version = "0.3.5", default-features = false }
-alloy-transport = { version = "0.3.5", default-features = false }
-alloy-rpc-types = { version = "0.3.5", default-features = false }
-alloy-rpc-client = { version = "0.3.5", default-features = false }
-alloy-rpc-types-engine = { version = "0.3.5", default-features = false }
-alloy-node-bindings = { version = "0.3.5", default-features = false }
-alloy-transport-http = { version = "0.3.5", default-features = false }
+alloy-consensus = { version = "0.3.6", default-features = false }
+alloy-transport = { version = "0.3.6", default-features = false }
+alloy-rpc-types = { version = "0.3.6", default-features = false }
+alloy-rpc-client = { version = "0.3.6", default-features = false }
+alloy-rpc-types-engine = { version = "0.3.6", default-features = false }
+alloy-node-bindings = { version = "0.3.6", default-features = false }
+alloy-transport-http = { version = "0.3.6", default-features = false }
 
 # OP Alloy
 op-alloy-consensus = { version = "0.2.12", default-features = false }

--- a/crates/preimage/src/key.rs
+++ b/crates/preimage/src/key.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[repr(u8)]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvSerialize, RkyvDeserialize))]
-#[cfg_attr(feature = "rkyv", archive_attr(derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)))]
 #[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
 pub enum PreimageKeyType {
     /// Local key types are local to a given instance of a fault-proof and context dependent.
@@ -64,7 +63,6 @@ impl TryFrom<u8> for PreimageKeyType {
 /// | [1, 32) | Data        |
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "rkyv", derive(Archive, RkyvSerialize, RkyvDeserialize))]
-#[cfg_attr(feature = "rkyv", archive_attr(derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)))]
 #[cfg_attr(feature = "serde", derive(SerdeSerialize, SerdeDeserialize))]
 pub struct PreimageKey {
     data: [u8; 31],


### PR DESCRIPTION
## Overview

Bumps all workspace dependencies, except for `c-kzg`. To update `c-kzg` to v2, alloy will also need to update.
