### PR TITLE
chore(readme): Remove `kona-plasma` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ rollup state transition in order to verify an [L2 output root][g-output-root] fr
 - [`mpt`](./crates/mpt): Utilities for interacting with the Merkle Patricia Trie in the client program.
 - [`executor`](./crates/executor): `no_std` stateless block executor for the [OP Stack][op-stack].
 - [`derive`](./crates/derive): `no_std` compatible implementation of the [derivation pipeline][g-derivation-pipeline].
-  - [`plasma`](./crates/plasma/): Plasma extension to `kona-derive`
 
 ## Book
 


### PR DESCRIPTION
## Overview

Removes the link to the old `kona-plasma` plugin within the README. It was removed from the codebase until further notice in https://github.com/anton-rs/kona/pull/443.
