### PR TITLE
fix(derive): Hoist AttributesBuilder Trait

### DIFF
--- a/crates/derive/src/errors.rs
+++ b/crates/derive/src/errors.rs
@@ -158,7 +158,7 @@ pub enum BatchDecompressionError {
 
 /// An [AttributesBuilder] Error.
 ///
-/// [AttributesBuilder]: crate::stages::AttributesBuilder
+/// [AttributesBuilder]: crate::traits::AttributesBuilder
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum BuilderError {
     /// Mismatched blocks.

--- a/crates/derive/src/pipeline/mod.rs
+++ b/crates/derive/src/pipeline/mod.rs
@@ -2,12 +2,9 @@
 
 /// Re-export trait arguments.
 pub use crate::traits::{
-    ChainProvider, DataAvailabilityProvider, L2ChainProvider, NextAttributes, OriginAdvancer,
-    OriginProvider, Pipeline, ResetProvider, ResettableStage, StepResult,
+    AttributesBuilder, ChainProvider, DataAvailabilityProvider, L2ChainProvider, NextAttributes,
+    OriginAdvancer, OriginProvider, Pipeline, ResetProvider, ResettableStage, StepResult,
 };
-
-/// Re-export stage types that are needed as inputs.
-pub use crate::stages::AttributesBuilder;
 
 /// Re-export error types.
 pub use crate::errors::{PipelineError, PipelineResult};

--- a/crates/derive/src/stages/attributes_queue.rs
+++ b/crates/derive/src/stages/attributes_queue.rs
@@ -11,14 +11,14 @@ use tracing::info;
 use crate::{
     batch::SingleBatch,
     errors::{PipelineError, PipelineResult, ResetError},
-    traits::{NextAttributes, OriginAdvancer, OriginProvider, ResettableStage},
+    traits::{AttributesBuilder, NextAttributes, OriginAdvancer, OriginProvider, ResettableStage},
 };
 
 mod deposits;
 pub(crate) use deposits::derive_deposits;
 
 mod builder;
-pub use builder::{AttributesBuilder, StatefulAttributesBuilder};
+pub use builder::StatefulAttributesBuilder;
 
 /// [AttributesProvider] is a trait abstraction that generalizes the [BatchQueue] stage.
 ///

--- a/crates/derive/src/stages/attributes_queue/builder.rs
+++ b/crates/derive/src/stages/attributes_queue/builder.rs
@@ -4,7 +4,7 @@ use super::derive_deposits;
 use crate::{
     errors::{BuilderError, PipelineError, PipelineErrorKind, PipelineResult},
     params::SEQUENCER_FEE_VAULT_ADDRESS,
-    traits::{ChainProvider, L2ChainProvider},
+    traits::{AttributesBuilder, ChainProvider, L2ChainProvider},
 };
 use alloc::{boxed::Box, fmt::Debug, string::ToString, sync::Arc, vec, vec::Vec};
 use alloy_eips::{eip2718::Encodable2718, BlockNumHash};
@@ -16,24 +16,6 @@ use op_alloy_consensus::Hardforks;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::{L1BlockInfoTx, L2BlockInfo};
 use op_alloy_rpc_types_engine::OptimismPayloadAttributes;
-
-/// The [AttributesBuilder] is responsible for preparing [OptimismPayloadAttributes]
-/// that can be used to construct an L2 Block containing only deposits.
-#[async_trait]
-pub trait AttributesBuilder {
-    /// Prepares a template [OptimismPayloadAttributes] that is ready to be used to build an L2
-    /// block. The block will contain deposits only, on top of the given L2 parent, with the L1
-    /// origin set to the given epoch.
-    /// By default, the [OptimismPayloadAttributes] template will have `no_tx_pool` set to true,
-    /// and no sequencer transactions. The caller has to modify the template to add transactions.
-    /// This can be done by either setting the `no_tx_pool` to false as sequencer, or by appending
-    /// batch transactions as the verifier.
-    async fn prepare_payload_attributes(
-        &mut self,
-        l2_parent: L2BlockInfo,
-        epoch: BlockNumHash,
-    ) -> PipelineResult<OptimismPayloadAttributes>;
-}
 
 /// A stateful implementation of the [AttributesBuilder].
 #[derive(Debug, Default)]

--- a/crates/derive/src/stages/mod.rs
+++ b/crates/derive/src/stages/mod.rs
@@ -33,9 +33,7 @@ mod batch_queue;
 pub use batch_queue::{BatchQueue, BatchQueueProvider};
 
 mod attributes_queue;
-pub use attributes_queue::{
-    AttributesBuilder, AttributesProvider, AttributesQueue, StatefulAttributesBuilder,
-};
+pub use attributes_queue::{AttributesProvider, AttributesQueue, StatefulAttributesBuilder};
 
 mod utils;
 pub use utils::decompress_brotli;

--- a/crates/derive/src/stages/test_utils/attributes_queue.rs
+++ b/crates/derive/src/stages/test_utils/attributes_queue.rs
@@ -3,8 +3,8 @@
 use crate::{
     batch::SingleBatch,
     errors::{BuilderError, PipelineError, PipelineErrorKind, PipelineResult},
-    stages::attributes_queue::{AttributesBuilder, AttributesProvider},
-    traits::{OriginAdvancer, OriginProvider, ResettableStage},
+    stages::attributes_queue::AttributesProvider,
+    traits::{AttributesBuilder, OriginAdvancer, OriginProvider, ResettableStage},
 };
 use alloc::{boxed::Box, string::ToString, vec::Vec};
 use alloy_eips::BlockNumHash;

--- a/crates/derive/src/traits/attributes.rs
+++ b/crates/derive/src/traits/attributes.rs
@@ -1,9 +1,10 @@
 //! Contains traits for working with payload attributes and their providers.
 
 use alloc::boxed::Box;
+use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use op_alloy_protocol::L2BlockInfo;
-use op_alloy_rpc_types_engine::OptimismAttributesWithParent;
+use op_alloy_rpc_types_engine::{OptimismAttributesWithParent, OptimismPayloadAttributes};
 
 use crate::errors::PipelineResult;
 
@@ -16,4 +17,22 @@ pub trait NextAttributes {
         &mut self,
         parent: L2BlockInfo,
     ) -> PipelineResult<OptimismAttributesWithParent>;
+}
+
+/// The [AttributesBuilder] is responsible for preparing [OptimismPayloadAttributes]
+/// that can be used to construct an L2 Block containing only deposits.
+#[async_trait]
+pub trait AttributesBuilder {
+    /// Prepares a template [OptimismPayloadAttributes] that is ready to be used to build an L2
+    /// block. The block will contain deposits only, on top of the given L2 parent, with the L1
+    /// origin set to the given epoch.
+    /// By default, the [OptimismPayloadAttributes] template will have `no_tx_pool` set to true,
+    /// and no sequencer transactions. The caller has to modify the template to add transactions.
+    /// This can be done by either setting the `no_tx_pool` to false as sequencer, or by appending
+    /// batch transactions as the verifier.
+    async fn prepare_payload_attributes(
+        &mut self,
+        l2_parent: L2BlockInfo,
+        epoch: BlockNumHash,
+    ) -> PipelineResult<OptimismPayloadAttributes>;
 }

--- a/crates/derive/src/traits/mod.rs
+++ b/crates/derive/src/traits/mod.rs
@@ -5,7 +5,7 @@ mod pipeline;
 pub use pipeline::{Pipeline, StepResult};
 
 mod attributes;
-pub use attributes::NextAttributes;
+pub use attributes::{AttributesBuilder, NextAttributes};
 
 mod data_sources;
 pub use data_sources::{AsyncIterator, BlobProvider, DataAvailabilityProvider};


### PR DESCRIPTION
### Description

Hoists the `AttributesBuilder` trait to allow the attributes builder to be moved easier in up-stack prs.