### PR TITLE
feat: Switch to `std::process::Command` when invoking the program binary

### DIFF
--- a/bin/host/src/lib.rs
+++ b/bin/host/src/lib.rs
@@ -23,9 +23,10 @@ use std::{
     io::{stderr, stdin, stdout},
     os::fd::{AsFd, AsRawFd},
     panic::AssertUnwindSafe,
+    process::Command,
     sync::Arc,
 };
-use tokio::{process::Command, sync::RwLock, task};
+use tokio::{sync::RwLock, task};
 use tracing::{debug, error, info};
 use util::Pipe;
 
@@ -213,7 +214,7 @@ pub async fn start_native_client_program(
         ])
         .expect("No errors may occur when mapping file descriptors.");
 
-    let status = command.status().await.map_err(|e| {
+    let status = command.status().map_err(|e| {
         error!(target: "client_program", "Failed to execute client program: {:?}", e);
         anyhow!("Failed to execute client program: {:?}", e)
     })?;


### PR DESCRIPTION
The use of [command-fds](https://crates.io/crates/command-fds) with tokio::process::Command causes rare, deterministic race conditions that lead to witness generation failures. These issues consistently occur for specific block ranges on OP Sepolia, Base, and OP Mainnet in [op-succinct](https://github.com/succinctlabs/op-succinct).

We should switch to std::process::Command to avoid these race conditions. This will increase resource usage for concurrent witness generation, and we can move back to `tokio` once the race condition issues are resolved.

I'm not exactly certain the source of the issue, but the Safety section of `tokio::process::Command` mentions some issues arising from file descriptors: https://tikv.github.io/doc/tokio/process/struct.Command.html#safety