### PR TITLE
chore(ci): Split online/offline tests

### DIFF
--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -10,11 +10,16 @@ jobs:
   cargo-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      matrix:
+        mode: ["online", "offline"]
+    name: test-${{ matrix.mode }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
           submodules: true
+      - uses: taiki-e/install-action@just
       - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -22,7 +27,12 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: cargo test
-        run: RUST_MIN_STACK=33554432 cargo nextest run --release --workspace --all --all-features --locked
+        run: |
+          if [[ ${{ contains(matrix.mode, online) }} == true ]]; then
+            just test-online
+          else
+            just test
+          fi
   cargo-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/crates/mpt/src/list_walker.rs
+++ b/crates/mpt/src/list_walker.rs
@@ -179,7 +179,7 @@ mod test {
     use alloy_rlp::Encodable;
 
     #[tokio::test]
-    async fn test_list_walker_online_receipts() {
+    async fn test_online_list_walker_receipts() {
         let (root, preimages, envelopes) = get_live_derivable_receipts_list().await.unwrap();
         let fetcher = TrieNodeProvider::new(preimages, BTreeMap::default(), BTreeMap::default());
         let list = OrderedListWalker::try_new_hydrated(root, &fetcher).unwrap();
@@ -193,7 +193,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_list_walker_online_transactions() {
+    async fn test_online_list_walker_transactions() {
         let (root, preimages, envelopes) = get_live_derivable_transactions_list().await.unwrap();
         let fetcher = TrieNodeProvider::new(preimages, BTreeMap::default(), BTreeMap::default());
         let list = OrderedListWalker::try_new_hydrated(root, &fetcher).unwrap();

--- a/justfile
+++ b/justfile
@@ -12,16 +12,16 @@ alias h := hack
 default:
   @just --list
 
-# Run all tests
+# Run all tests (excluding online tests)
 tests: test test-docs
 
-# Runs `cargo hack check` against the workspace
-hack:
-  cargo hack check --feature-powerset --no-dev-deps
+# Test for the native target with all features. By default, excludes online tests.
+test *args="-E '!test(test_online)'":
+  cargo nextest run --workspace --all --all-features {{args}}
 
-# Test for the native target with all features
-test *args='':
-  cargo nextest run --workspace --all --all-features $@
+# Run all online tests
+test-online:
+  just test "-E 'test(test_online)'"
 
 # Run action tests for the client program on the native target
 action-tests test_name='Test_ProgramAction':
@@ -54,6 +54,10 @@ clean-actions:
 
 # Lint the workspace for all available targets
 lint-all: lint-native lint-cannon lint-asterisc lint-docs
+
+# Runs `cargo hack check` against the workspace
+hack:
+  cargo hack check --feature-powerset --no-dev-deps
 
 # Fixes the formatting of the workspace
 fmt-native-fix:


### PR DESCRIPTION
## Overview

Splits the tests that require a network connection within the `justfile` test directives.

Locally, when running `just t`, `just tests`, or `just test`, the online tests (tests that start w/ `test_online`) are no longer ran by default.

A new justfile recipe, `just test-online` has been added to run the online tests.
