### PR TITLE
chore(derive): [Holocene] Drain previous channel in one iteration

### DIFF
--- a/crates/derive/src/stages/frame_queue.rs
+++ b/crates/derive/src/stages/frame_queue.rs
@@ -96,7 +96,7 @@ where
                 // Find the index of the first frame in the queue with the same channel ID
                 // as the previous frame.
                 let first_frame =
-                    self.queue.iter().position(|f| f.id == prev_frame.id).expect("Infalliable");
+                    self.queue.iter().position(|f| f.id == prev_frame.id).expect("infallible");
 
                 // Drain all frames from the previous channel.
                 let drained = self.queue.drain(first_frame..=i);
@@ -480,7 +480,7 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_holocene_replace_channel() {
         let frames = vec![
-            // - First Channel - VALID & CLOSED --
+            // -- First Channel - VALID & CLOSED --
             Frame { id: [0xDD; 16], number: 0, data: vec![0xDD; 50], is_last: false },
             Frame { id: [0xDD; 16], number: 1, data: vec![0xDD; 50], is_last: true },
             // -- Second Channel - VALID & NOT CLOSED / DROPPED --

--- a/crates/derive/src/stages/frame_queue.rs
+++ b/crates/derive/src/stages/frame_queue.rs
@@ -523,7 +523,7 @@ pub(crate) mod tests {
         mock.set_origin(BlockInfo::default());
         let mut frame_queue = FrameQueue::new(mock, Arc::new(config));
         assert!(frame_queue.is_holocene_active(BlockInfo::default()));
-        for frame in frames.iter().filter(|f| f.id != [0xEE; 16]) {
+        for frame in frames[4..].iter() {
             let frame_decoded = frame_queue.next_frame().await.unwrap();
             assert_eq!(frame_decoded, *frame);
         }

--- a/crates/derive/src/stages/frame_queue.rs
+++ b/crates/derive/src/stages/frame_queue.rs
@@ -503,17 +503,17 @@ pub(crate) mod tests {
         let err = frame_queue.next_frame().await.unwrap_err();
         assert_eq!(err, PipelineError::Eof.temp());
     }
-  
+
     #[tokio::test]
-    async fn test_holocene_replace_channel() {
+    async fn test_holocene_interleaved_invalid_channel() {
         let frames = vec![
-            // -- First Channel - VALID & CLOSED --
-            Frame { id: [0xDD; 16], number: 0, data: vec![0xDD; 50], is_last: false },
-            Frame { id: [0xDD; 16], number: 1, data: vec![0xDD; 50], is_last: true },
-            // -- Second Channel - VALID & NOT CLOSED / DROPPED --
-            Frame { id: [0xEE; 16], number: 0, data: vec![0xDD; 50], is_last: false },
-            Frame { id: [0xEE; 16], number: 1, data: vec![0xDD; 50], is_last: false },
-            // -- Third Channel - VALID & CLOSED / REPLACES CHANNEL #2 --
+            // -- First channel is dropped since it is replaced by the second channel --
+            // -- Second channel is dropped since it isn't closed --
+            Frame { id: [0x01; 16], number: 0, data: vec![0xDD; 50], is_last: false },
+            Frame { id: [0x02; 16], number: 0, data: vec![0xDD; 50], is_last: false },
+            Frame { id: [0x01; 16], number: 1, data: vec![0xDD; 50], is_last: true },
+            Frame { id: [0x02; 16], number: 1, data: vec![0xDD; 50], is_last: false },
+            // -- Third Channel - VALID & CLOSED --
             Frame { id: [0xFF; 16], number: 0, data: vec![0xDD; 50], is_last: false },
             Frame { id: [0xFF; 16], number: 1, data: vec![0xDD; 50], is_last: true },
         ];


### PR DESCRIPTION
## Overview

Drains the entire previous channel at one time, rather than over multiple iterations, if the following case is met:

> If a first frame is decoded while the previous frame isn't a last frame (i.e., is_last is false), all previous frames for the same channel are dropped and this new first frame remains in the queue.

Also fixes a small issue w/ the `DERIVED_FRAMES_COUNT` metric's accounting, where it was counting dropped frames.

### Tests

Added a new test for this functionality, when there is a valid, closed channel earlier on in the frame queue @ `test_holocene_replace_channel`.
