### PR TITLE
chore(workspace): `just lint`

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,6 +2,7 @@ set positional-arguments
 alias t := tests
 alias la := lint-all
 alias l := lint-native
+alias lint := lint-native
 alias f := fmt-native-fix
 alias b := build
 alias d := docker-build-ts


### PR DESCRIPTION
## Overview

```
[01:34] 🦀 v1.81.0 cl@kona:main [$]
 just lint
error: Justfile does not contain recipe `lint`.
```

is my mortal enemy. Adds a `just lint` alias for `just lint-native`.
