### PR TITLE
chore: Alloy Map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,9 +1156,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.22"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9540e661f81799159abee814118cc139a2004b3a3aa3ea37724a1b66530b90e0"
+checksum = "3bbb537bb4a30b90362caddba8f360c0a56bc13d3a5570028e7197204cb54a17"
 dependencies = [
  "jobserver",
  "libc",
@@ -1277,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
+checksum = "0121754e84117e65f9d90648ee6aa4882a6e63110307ab73967a4c5e7e69e586"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2347,7 +2347,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "brotli",
- "hashbrown",
  "kona-primitives",
  "lazy_static",
  "lru",
@@ -2890,9 +2889,12 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "82881c4be219ab5faaf2ad5e5e5ecdff8c66bd7402ca3160975c93b24961afd1"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "oorandom"
@@ -3183,6 +3185,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powerfmt"
@@ -3500,18 +3508,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355ae415ccd3a04315d3f8246e86d67689ea74d88d915576e1589a351062a13b"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3521,9 +3529,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3538,9 +3546,9 @@ checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rend"
@@ -4382,9 +4390,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -4774,9 +4782,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uint"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ kona-primitives = { path = "crates/primitives", version = "0.0.2", default-featu
 anyhow = { version = "1.0.89", default-features = false }
 thiserror = { git = "https://github.com/quartiq/thiserror", branch = "no-std", default-features = false }
 cfg-if = "1.0.0"
-hashbrown = "0.14.5"
 spin = { version = "0.9.8", features = ["mutex"] }
 lru = "0.12.4"
 async-trait = "0.1.82"

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 alloy-eips.workspace = true
 alloy-rlp = { workspace = true, features = ["derive"] }
 alloy-consensus = { workspace = true, features = ["k256"] }
-alloy-primitives = { workspace = true, features = ["rlp", "k256"] }
+alloy-primitives = { workspace = true, features = ["rlp", "k256", "map"] }
 alloy-rpc-types-engine.workspace = true
 op-alloy-consensus = { workspace = true, features = ["k256"] }
 op-alloy-protocol.workspace = true
@@ -24,7 +24,6 @@ op-alloy-genesis.workspace = true
 op-alloy-rpc-types-engine.workspace = true
 
 # General
-hashbrown.workspace = true
 unsigned-varint.workspace = true
 miniz_oxide.workspace = true
 brotli.workspace = true

--- a/crates/derive/src/stages/channel_bank.rs
+++ b/crates/derive/src/stages/channel_bank.rs
@@ -7,10 +7,9 @@ use crate::{
     traits::{OriginAdvancer, OriginProvider, ResettableStage},
 };
 use alloc::{boxed::Box, collections::VecDeque, sync::Arc};
-use alloy_primitives::{hex, Bytes};
+use alloy_primitives::{hex, map::HashMap, Bytes};
 use async_trait::async_trait;
 use core::fmt::Debug;
-use hashbrown::HashMap;
 use op_alloy_genesis::{RollupConfig, SystemConfig};
 use op_alloy_protocol::{BlockInfo, Channel, ChannelId, Frame};
 use tracing::{trace, warn};
@@ -128,7 +127,7 @@ where
         {
             // For each channel, get the number of frames and record it in the CHANNEL_FRAME_COUNT
             // histogram metric.
-            for (_, channel) in &self.channels {
+            for channel in self.channels.values() {
                 crate::observe!(CHANNEL_FRAME_COUNT, channel.len() as f64);
             }
         }

--- a/crates/derive/src/stages/test_utils/sys_config_fetcher.rs
+++ b/crates/derive/src/stages/test_utils/sys_config_fetcher.rs
@@ -2,9 +2,9 @@
 
 use crate::{block::OpBlock, traits::L2ChainProvider};
 use alloc::{boxed::Box, sync::Arc};
+use alloy_primitives::map::HashMap;
 use anyhow::Result;
 use async_trait::async_trait;
-use hashbrown::HashMap;
 use op_alloy_genesis::{RollupConfig, SystemConfig};
 use op_alloy_protocol::L2BlockInfo;
 

--- a/crates/derive/src/traits/test_utils.rs
+++ b/crates/derive/src/traits/test_utils.rs
@@ -10,11 +10,10 @@ use crate::{
 use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_eips::eip4844::Blob;
-use alloy_primitives::{Address, Bytes, B256};
+use alloy_primitives::{map::HashMap, Address, Bytes, B256};
 use anyhow::Result;
 use async_trait::async_trait;
 use core::fmt::Debug;
-use hashbrown::HashMap;
 use kona_primitives::IndexedBlobHash;
 use op_alloy_genesis::{RollupConfig, SystemConfig};
 use op_alloy_protocol::{BlockInfo, L2BlockInfo};


### PR DESCRIPTION
### Description

Removes the `hashbrown` dependency, using the [recently introduced `map` primitive](https://github.com/alloy-rs/core/pull/743) in [`alloy-primitives`](https://github.com/alloy-rs/core/tree/main/crates/primitives).