### PR TITLE
feat(derive): `BatchStream` buffering

### DIFF
--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -25,7 +25,7 @@ pub trait BatchQueueProvider {
     async fn next_batch(
         &mut self,
         parent: L2BlockInfo,
-        origins: &[BlockInfo],
+        l1_origins: &[BlockInfo],
     ) -> PipelineResult<Batch>;
 
     /// Allows the [BatchQueue] to flush the buffer in the [crate::stages::BatchStream]

--- a/crates/derive/src/stages/batch_stream.rs
+++ b/crates/derive/src/stages/batch_stream.rs
@@ -1,18 +1,17 @@
 //! This module contains the `BatchStream` stage.
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use crate::{
+    batch::{Batch, SingleBatch, SpanBatch},
+    errors::{PipelineEncodingError, PipelineError, PipelineResult},
+    stages::BatchQueueProvider,
+    traits::{OriginAdvancer, OriginProvider, ResettableStage},
+};
+use alloc::{boxed::Box, collections::VecDeque, sync::Arc};
 use async_trait::async_trait;
 use core::fmt::Debug;
 use op_alloy_genesis::{RollupConfig, SystemConfig};
 use op_alloy_protocol::{BlockInfo, L2BlockInfo};
 use tracing::trace;
-
-use crate::{
-    batch::{Batch, SingleBatch, SpanBatch},
-    errors::{PipelineError, PipelineResult},
-    stages::BatchQueueProvider,
-    traits::{OriginAdvancer, OriginProvider, ResettableStage},
-};
 
 /// Provides [Batch]es for the [BatchStream] stage.
 #[async_trait]
@@ -43,7 +42,7 @@ where
     /// There can only be a single staged span batch.
     span: Option<SpanBatch>,
     /// A buffer of single batches derived from the [SpanBatch].
-    buffer: Vec<SingleBatch>,
+    buffer: VecDeque<SingleBatch>,
     /// A reference to the rollup config, used to check
     /// if the [BatchStream] stage should be activated.
     config: Arc<RollupConfig>,
@@ -55,7 +54,7 @@ where
 {
     /// Create a new [BatchStream] stage.
     pub const fn new(prev: P, config: Arc<RollupConfig>) -> Self {
-        Self { prev, span: None, buffer: Vec::new(), config }
+        Self { prev, span: None, buffer: VecDeque::new(), config }
     }
 
     /// Returns if the [BatchStream] stage is active based on the
@@ -66,9 +65,32 @@ where
     }
 
     /// Gets a [SingleBatch] from the in-memory buffer.
-    pub fn get_single_batch(&mut self) -> Option<SingleBatch> {
+    pub fn get_single_batch(
+        &mut self,
+        parent: L2BlockInfo,
+        l1_origins: &[BlockInfo],
+    ) -> PipelineResult<SingleBatch> {
         trace!(target: "batch_span", "Attempting to get a SingleBatch from buffer len: {}", self.buffer.len());
-        unimplemented!()
+
+        self.try_hydrate_buffer(parent, l1_origins)?;
+        self.buffer.pop_front().ok_or_else(|| PipelineError::NotEnoughData.temp())
+    }
+
+    /// Hydrates the buffer with single batches derived from the span batch, if there is one
+    /// queued up.
+    pub fn try_hydrate_buffer(
+        &mut self,
+        parent: L2BlockInfo,
+        l1_origins: &[BlockInfo],
+    ) -> PipelineResult<()> {
+        if let Some(span) = self.span.take() {
+            self.buffer.extend(
+                span.get_singular_batches(l1_origins, parent).map_err(|e| {
+                    PipelineError::BadEncoding(PipelineEncodingError::from(e)).crit()
+                })?,
+            );
+        }
+        Ok(())
     }
 }
 
@@ -83,34 +105,34 @@ where
         }
     }
 
-    async fn next_batch(&mut self, _: L2BlockInfo, _: &[BlockInfo]) -> PipelineResult<Batch> {
+    async fn next_batch(
+        &mut self,
+        parent: L2BlockInfo,
+        l1_origins: &[BlockInfo],
+    ) -> PipelineResult<Batch> {
         // If the stage is not active, "pass" the next batch
         // through this stage to the BatchQueue stage.
         if !self.is_active()? {
             trace!(target: "batch_span", "BatchStream stage is inactive, pass-through.");
-            return self.prev.next_batch().await;
+            return self.prev.next_batch(parent, l1_origins).await;
         }
 
-        // First, attempt to pull a SinguleBatch out of the buffer.
-        if let Some(b) = self.get_single_batch() {
-            return Ok(Batch::Single(b));
+        // If there's no span batch, attempt to pull one from the previous stage.
+        if self.span.is_none() {
+            // Safety: bubble up any errors from the batch reader.
+            let batch = self.prev.next_batch(parent, l1_origins).await?;
+
+            // If the next batch is a singular batch, it is immediately
+            // forwarded to the `BatchQueue` stage. Otherwise, we buffer
+            // the span batch in this stage.
+            match batch {
+                Batch::Single(b) => return Ok(Batch::Single(b)),
+                Batch::Span(b) => self.span = Some(b),
+            }
         }
-
-        // Safety: bubble up any errors from the batch reader.
-        let batch = self.prev.next_batch().await?;
-
-        // If the next batch is a singular batch, it is immediately
-        // forwarded to the `BatchQueue` stage.
-        let Batch::Span(b) = batch else {
-            return Ok(batch);
-        };
-
-        // Set the current span batch.
-        self.span = Some(b);
 
         // Attempt to pull a SingleBatch out of the SpanBatch.
-        self.get_single_batch()
-            .map_or_else(|| Err(PipelineError::NotEnoughData.temp()), |b| Ok(Batch::Single(b)))
+        self.get_single_batch(parent, l1_origins).map(Batch::Single)
     }
 }
 

--- a/crates/derive/src/stages/channel_reader.rs
+++ b/crates/derive/src/stages/channel_reader.rs
@@ -110,11 +110,7 @@ where
         self.next_channel();
     }
 
-    async fn next_batch(
-        &mut self,
-        _: L2BlockInfo,
-        _: &[BlockInfo],
-    ) -> PipelineResult<Batch> {
+    async fn next_batch(&mut self, _: L2BlockInfo, _: &[BlockInfo]) -> PipelineResult<Batch> {
         crate::timer!(START, STAGE_ADVANCE_RESPONSE_TIME, &["channel_reader"], timer);
         if let Err(e) = self.set_batch_reader().await {
             debug!(target: "channel-reader", "Failed to set batch reader: {:?}", e);
@@ -259,7 +255,10 @@ mod test {
     async fn test_next_batch_batch_reader_set_fails() {
         let mock = MockChannelReaderProvider::new(vec![Err(PipelineError::Eof.temp())]);
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
-        assert_eq!(reader.next_batch(Default::default(), &[]).await, Err(PipelineError::Eof.temp()));
+        assert_eq!(
+            reader.next_batch(Default::default(), &[]).await,
+            Err(PipelineError::Eof.temp())
+        );
         assert!(reader.next_batch.is_none());
     }
 
@@ -280,7 +279,10 @@ mod test {
         let second = first.split_to(first.len() / 2);
         let mock = MockChannelReaderProvider::new(vec![Ok(Some(first)), Ok(Some(second))]);
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
-        assert_eq!(reader.next_batch(Default::default(), &[]).await, Err(PipelineError::NotEnoughData.temp()));
+        assert_eq!(
+            reader.next_batch(Default::default(), &[]).await,
+            Err(PipelineError::NotEnoughData.temp())
+        );
         assert!(reader.next_batch.is_none());
     }
 

--- a/crates/derive/src/stages/channel_reader.rs
+++ b/crates/derive/src/stages/channel_reader.rs
@@ -193,8 +193,8 @@ impl BatchReader {
             }
 
             let compression_type = data[0];
-            if (compression_type & 0x0F) == ZLIB_DEFLATE_COMPRESSION_METHOD
-                || (compression_type & 0x0F) == ZLIB_RESERVED_COMPRESSION_METHOD
+            if (compression_type & 0x0F) == ZLIB_DEFLATE_COMPRESSION_METHOD ||
+                (compression_type & 0x0F) == ZLIB_RESERVED_COMPRESSION_METHOD
             {
                 self.decompressed = decompress_to_vec_zlib(&data).ok()?;
             } else if compression_type == CHANNEL_VERSION_BROTLI {

--- a/crates/derive/src/stages/channel_reader.rs
+++ b/crates/derive/src/stages/channel_reader.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use core::fmt::Debug;
 use miniz_oxide::inflate::decompress_to_vec_zlib;
 use op_alloy_genesis::{RollupConfig, SystemConfig};
-use op_alloy_protocol::{BlockInfo, L2BlockInfo};
+use op_alloy_protocol::BlockInfo;
 use tracing::{debug, error, warn};
 
 /// ZLIB Deflate Compression Method.
@@ -110,7 +110,7 @@ where
         self.next_channel();
     }
 
-    async fn next_batch(&mut self, _: L2BlockInfo, _: &[BlockInfo]) -> PipelineResult<Batch> {
+    async fn next_batch(&mut self) -> PipelineResult<Batch> {
         crate::timer!(START, STAGE_ADVANCE_RESPONSE_TIME, &["channel_reader"], timer);
         if let Err(e) = self.set_batch_reader().await {
             debug!(target: "channel-reader", "Failed to set batch reader: {:?}", e);
@@ -193,8 +193,8 @@ impl BatchReader {
             }
 
             let compression_type = data[0];
-            if (compression_type & 0x0F) == ZLIB_DEFLATE_COMPRESSION_METHOD ||
-                (compression_type & 0x0F) == ZLIB_RESERVED_COMPRESSION_METHOD
+            if (compression_type & 0x0F) == ZLIB_DEFLATE_COMPRESSION_METHOD
+                || (compression_type & 0x0F) == ZLIB_RESERVED_COMPRESSION_METHOD
             {
                 self.decompressed = decompress_to_vec_zlib(&data).ok()?;
             } else if compression_type == CHANNEL_VERSION_BROTLI {
@@ -255,10 +255,7 @@ mod test {
     async fn test_next_batch_batch_reader_set_fails() {
         let mock = MockChannelReaderProvider::new(vec![Err(PipelineError::Eof.temp())]);
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
-        assert_eq!(
-            reader.next_batch(Default::default(), &[]).await,
-            Err(PipelineError::Eof.temp())
-        );
+        assert_eq!(reader.next_batch().await, Err(PipelineError::Eof.temp()));
         assert!(reader.next_batch.is_none());
     }
 
@@ -267,7 +264,7 @@ mod test {
         let mock = MockChannelReaderProvider::new(vec![Ok(None)]);
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
         assert!(matches!(
-            reader.next_batch(Default::default(), &[]).await.unwrap_err(),
+            reader.next_batch().await.unwrap_err(),
             PipelineErrorKind::Temporary(PipelineError::ChannelReaderEmpty)
         ));
         assert!(reader.next_batch.is_none());
@@ -279,10 +276,7 @@ mod test {
         let second = first.split_to(first.len() / 2);
         let mock = MockChannelReaderProvider::new(vec![Ok(Some(first)), Ok(Some(second))]);
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
-        assert_eq!(
-            reader.next_batch(Default::default(), &[]).await,
-            Err(PipelineError::NotEnoughData.temp())
-        );
+        assert_eq!(reader.next_batch().await, Err(PipelineError::NotEnoughData.temp()));
         assert!(reader.next_batch.is_none());
     }
 
@@ -291,7 +285,7 @@ mod test {
         let raw = new_compressed_batch_data();
         let mock = MockChannelReaderProvider::new(vec![Ok(Some(raw))]);
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
-        let res = reader.next_batch(Default::default(), &[]).await.unwrap();
+        let res = reader.next_batch().await.unwrap();
         matches!(res, Batch::Span(_));
         assert!(reader.next_batch.is_some());
     }


### PR DESCRIPTION
## Overview

Implements the rest of the `BatchStream`, buffering the span batch that is received and sending only `SingleBatch`es to the batch queue.