### PR TITLE
feat(derive): AttributesQueue Traits

### DIFF
--- a/crates/derive/src/attributes/mod.rs
+++ b/crates/derive/src/attributes/mod.rs
@@ -1,10 +1,10 @@
-//! The [`AttributesBuilder`] and it's default implementation.
+//! The [`AttributesQueueBuilder`] and it's default implementation.
 
 use crate::{
     errors::{
         BuilderError, PipelineEncodingError, PipelineError, PipelineErrorKind, PipelineResult,
     },
-    traits::{AttributesBuilder, ChainProvider, L2ChainProvider},
+    traits::{AttributesQueueBuilder, ChainProvider, L2ChainProvider},
 };
 use alloc::{boxed::Box, fmt::Debug, string::ToString, sync::Arc, vec, vec::Vec};
 use alloy_consensus::{Eip658Value, Receipt};
@@ -22,7 +22,7 @@ use op_alloy_rpc_types_engine::OptimismPayloadAttributes;
 pub const SEQUENCER_FEE_VAULT_ADDRESS: Address =
     address!("4200000000000000000000000000000000000011");
 
-/// A stateful implementation of the [AttributesBuilder].
+/// A stateful implementation of the [AttributesQueueBuilder].
 #[derive(Debug, Default)]
 pub struct StatefulAttributesBuilder<L1P, L2P>
 where
@@ -49,7 +49,7 @@ where
 }
 
 #[async_trait]
-impl<L1P, L2P> AttributesBuilder for StatefulAttributesBuilder<L1P, L2P>
+impl<L1P, L2P> AttributesQueueBuilder for StatefulAttributesBuilder<L1P, L2P>
 where
     L1P: ChainProvider + Debug + Send,
     L2P: L2ChainProvider + Debug + Send,

--- a/crates/derive/src/errors.rs
+++ b/crates/derive/src/errors.rs
@@ -168,7 +168,7 @@ pub enum BatchDecompressionError {
 
 /// An [AttributesBuilder] Error.
 ///
-/// [AttributesBuilder]: crate::traits::AttributesBuilder
+/// [AttributesBuilder]: crate::traits::AttributesQueueBuilder
 #[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum BuilderError {
     /// Mismatched blocks.

--- a/crates/derive/src/pipeline/builder.rs
+++ b/crates/derive/src/pipeline/builder.rs
@@ -1,7 +1,8 @@
 //! Contains the `PipelineBuilder` object that is used to build a `DerivationPipeline`.
 
 use super::{
-    AttributesBuilder, ChainProvider, DataAvailabilityProvider, DerivationPipeline, L2ChainProvider,
+    AttributesQueueBuilder, ChainProvider, DataAvailabilityProvider, DerivationPipeline,
+    L2ChainProvider,
 };
 use crate::stages::{
     AttributesQueue, BatchQueue, BatchStream, ChannelBank, ChannelReader, FrameQueue, L1Retrieval,
@@ -25,7 +26,7 @@ type AttributesQueueStage<DAP, P, T, B> = AttributesQueue<BatchQueueStage<DAP, P
 #[derive(Debug)]
 pub struct PipelineBuilder<B, P, T, D>
 where
-    B: AttributesBuilder + Send + Debug,
+    B: AttributesQueueBuilder + Send,
     P: ChainProvider + Send + Sync + Debug,
     T: L2ChainProvider + Clone + Send + Sync + Debug,
     D: DataAvailabilityProvider + Send + Sync + Debug,
@@ -40,7 +41,7 @@ where
 
 impl<B, P, T, D> Default for PipelineBuilder<B, P, T, D>
 where
-    B: AttributesBuilder + Send + Debug,
+    B: AttributesQueueBuilder + Send,
     P: ChainProvider + Send + Sync + Debug,
     T: L2ChainProvider + Clone + Send + Sync + Debug,
     D: DataAvailabilityProvider + Send + Sync + Debug,
@@ -59,7 +60,7 @@ where
 
 impl<B, P, T, D> PipelineBuilder<B, P, T, D>
 where
-    B: AttributesBuilder + Send + Debug,
+    B: AttributesQueueBuilder + Send,
     P: ChainProvider + Send + Sync + Debug,
     T: L2ChainProvider + Clone + Send + Sync + Debug,
     D: DataAvailabilityProvider + Send + Sync + Debug,
@@ -114,7 +115,7 @@ where
 impl<B, P, T, D> From<PipelineBuilder<B, P, T, D>>
     for DerivationPipeline<AttributesQueueStage<D, P, T, B>, T>
 where
-    B: AttributesBuilder + Send + Debug,
+    B: AttributesQueueBuilder + Send,
     P: ChainProvider + Send + Sync + Debug,
     T: L2ChainProvider + Clone + Send + Sync + Debug,
     D: DataAvailabilityProvider + Send + Sync + Debug,

--- a/crates/derive/src/pipeline/mod.rs
+++ b/crates/derive/src/pipeline/mod.rs
@@ -2,8 +2,9 @@
 
 /// Re-export trait arguments.
 pub use crate::traits::{
-    AttributesBuilder, ChainProvider, DataAvailabilityProvider, L2ChainProvider, NextAttributes,
-    OriginAdvancer, OriginProvider, Pipeline, ResetProvider, ResettableStage, StepResult,
+    AttributesQueueBuilder, ChainProvider, DataAvailabilityProvider, L2ChainProvider,
+    NextAttributes, OriginAdvancer, OriginProvider, Pipeline, ResetProvider, ResettableStage,
+    StepResult,
 };
 
 /// Re-export error types.

--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -3,8 +3,9 @@
 use crate::{
     batch::{Batch, BatchValidity, BatchWithInclusionBlock, SingleBatch},
     errors::{PipelineEncodingError, PipelineError, PipelineErrorKind, PipelineResult, ResetError},
-    stages::attributes_queue::AttributesProvider,
-    traits::{L2ChainProvider, OriginAdvancer, OriginProvider, ResettableStage},
+    traits::{
+        AttributesQueuePrior, L2ChainProvider, OriginAdvancer, OriginProvider, ResettableStage,
+    },
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use async_trait::async_trait;
@@ -264,7 +265,7 @@ where
 }
 
 #[async_trait]
-impl<P, BF> AttributesProvider for BatchQueue<P, BF>
+impl<P, BF> AttributesQueuePrior for BatchQueue<P, BF>
 where
     P: BatchQueueProvider + OriginAdvancer + OriginProvider + ResettableStage + Send + Debug,
     BF: L2ChainProvider + Send + Debug,

--- a/crates/derive/src/stages/mod.rs
+++ b/crates/derive/src/stages/mod.rs
@@ -36,7 +36,7 @@ mod batch_queue;
 pub use batch_queue::{BatchQueue, BatchQueueProvider};
 
 mod attributes_queue;
-pub use attributes_queue::{AttributesProvider, AttributesQueue};
+pub use attributes_queue::AttributesQueue;
 
 mod utils;
 pub use utils::decompress_brotli;

--- a/crates/derive/src/stages/test_utils/attributes_queue.rs
+++ b/crates/derive/src/stages/test_utils/attributes_queue.rs
@@ -3,8 +3,10 @@
 use crate::{
     batch::SingleBatch,
     errors::{BuilderError, PipelineError, PipelineErrorKind, PipelineResult},
-    stages::attributes_queue::AttributesProvider,
-    traits::{AttributesBuilder, OriginAdvancer, OriginProvider, ResettableStage},
+    traits::{
+        AttributesQueueBuilder, AttributesQueuePrior, OriginAdvancer, OriginProvider,
+        ResettableStage,
+    },
 };
 use alloc::{boxed::Box, string::ToString, vec::Vec};
 use alloy_eips::BlockNumHash;
@@ -21,7 +23,7 @@ pub struct MockAttributesBuilder {
 }
 
 #[async_trait]
-impl AttributesBuilder for MockAttributesBuilder {
+impl AttributesQueueBuilder for MockAttributesBuilder {
     /// Prepares the [PayloadAttributes] for the next payload.
     async fn prepare_payload_attributes(
         &mut self,
@@ -68,7 +70,7 @@ impl ResettableStage for MockAttributesProvider {
 }
 
 #[async_trait]
-impl AttributesProvider for MockAttributesProvider {
+impl AttributesQueuePrior for MockAttributesProvider {
     async fn next_batch(&mut self, _parent: L2BlockInfo) -> PipelineResult<SingleBatch> {
         self.batches.pop().ok_or(PipelineError::Eof.temp())?
     }

--- a/crates/derive/src/traits/mod.rs
+++ b/crates/derive/src/traits/mod.rs
@@ -4,8 +4,8 @@
 mod pipeline;
 pub use pipeline::{Pipeline, StepResult};
 
-mod attributes;
-pub use attributes::{AttributesBuilder, NextAttributes};
+mod attributes_queue;
+pub use attributes_queue::{AttributesQueueBuilder, AttributesQueuePrior, NextAttributes};
 
 mod data_sources;
 pub use data_sources::{AsyncIterator, BlobProvider, DataAvailabilityProvider};


### PR DESCRIPTION
### Description

Hoists `AttributesQueue` traits, setting up stages for auto-impls.

We can apply this refactor across all stages to provide a clean split between stage traits and stage implementations within the `kona-derive` crate.