### PR TITLE
chore(ci): Pin action tests monorepo rev

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -17,6 +17,8 @@ jobs:
       - name: Clone monorepo
         run: |
           git clone https://github.com/ethereum-optimism/monorepo
+          # September 30, 2024
+          cd monorepo && git checkout d05fb505809717282d5cee7264a09d26002a4ddd
       - name: Install just
         uses: taiki-e/install-action@just
       - name: Install Rust stable toolchain


### PR DESCRIPTION
## Overview

Pins the version of the `monorepo` we use for action tests in CI.