### PR TITLE
feat(trusted-sync): Holocene re-validate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4801,6 +4801,7 @@ dependencies = [
  "kona-primitives",
  "kona-providers-alloy",
  "lazy_static",
+ "op-alloy-consensus",
  "op-alloy-genesis",
  "op-alloy-rpc-types-engine",
  "prometheus",

--- a/examples/trusted-sync/Cargo.toml
+++ b/examples/trusted-sync/Cargo.toml
@@ -36,4 +36,5 @@ alloy-provider = { workspace = true, default-features = false }
 alloy-transport = { workspace = true, default-features = false }
 op-alloy-genesis.workspace = true
 op-alloy-rpc-types-engine.workspace = true
+op-alloy-consensus.workspace = true
 alloy-rpc-types-engine.workspace = true


### PR DESCRIPTION
## Overview

Attempts to re-validate a payload with a deposit-only payload in `trusted-sync`, per Holocene fork rules.