### PR TITLE
chore: Span Batch Prefix: no BatchValidity::Future 

### DIFF
--- a/crates/derive/src/stages/batch_stream.rs
+++ b/crates/derive/src/stages/batch_stream.rs
@@ -153,6 +153,8 @@ where
 
                             return Err(PipelineError::Eof.temp());
                         }
+                        // Safety: BatchValidity::Future should never be thrown by check_batch_prefix.
+                        // TODO: validate this with a test
                         BatchValidity::Undecided | BatchValidity::Future => {
                             return Err(PipelineError::NotEnoughData.temp())
                         }


### PR DESCRIPTION
### Description

TODO: add a test to assert `span_batch_prefix` check never returns a batch validity future.

prop test this?