### PR TITLE
fix(codecov): Ignore Test Utilities

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -18,10 +18,8 @@ coverage:
         only_pulls: true
 
 ignore:
-  - "tests"
-  - "test_util.rs"
-  - "test_utils.rs"
-  - "crates/derive/src/stages/test_utils"
+  - "**/test_util*"
+  - "**/tests*"
   - "bin/"
 
 # Make comments less noisy

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -18,6 +18,7 @@ coverage:
         only_pulls: true
 
 ignore:
+  - "**/test_utils*"
   - "**/test_util*"
   - "**/tests*"
   - "bin/"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,6 @@
 # ref: https://docs.codecov.com/docs/codecovyml-reference
 coverage:
-  range: 75..100
+  range: 80..100
   round: down
   precision: 1
   status:
@@ -18,6 +18,7 @@ coverage:
         only_pulls: true
 
 ignore:
+  - "**/test_utils/*"
   - "**/test_utils*"
   - "**/test_util*"
   - "**/tests*"


### PR DESCRIPTION
### Description

Fixes codecov to ignore all test utilities.

Also bumps the threshold up to 80 since we should not see regression > 3%