### PR TITLE
chore(providers): Codecov Ignore Alloy-backed Providers

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -23,6 +23,8 @@ ignore:
   - "**/test_util*"
   - "**/tests*"
   - "bin/"
+  - "crates/kona-providers-alloy/src/alloy_providers.rs"  # Flaky testing with online providers
+  - "crates/kona-providers-alloy/src/beacon_client.rs"  # Flaky testing with online providers
 
 # Make comments less noisy
 comment:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -23,8 +23,8 @@ ignore:
   - "**/test_util*"
   - "**/tests*"
   - "bin/"
-  - "crates/kona-providers-alloy/src/alloy_providers.rs"  # Flaky testing with online providers
-  - "crates/kona-providers-alloy/src/beacon_client.rs"  # Flaky testing with online providers
+  - "crates/providers-alloy/src/alloy_providers.rs"  # Flaky testing with online providers
+  - "crates/providers-alloy/src/beacon_client.rs"  # Flaky testing with online providers
 
 # Make comments less noisy
 comment:

--- a/crates/providers-alloy/src/alloy_providers.rs
+++ b/crates/providers-alloy/src/alloy_providers.rs
@@ -448,49 +448,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore]
-    async fn test_alloy_chain_provider_header_by_hash() {
-        let mut provider = AlloyChainProvider::new(default_provider());
-        let hash = alloy_primitives::b256!(
-            "5224e37a8db899839e23c9fa957971cacea09295d6824a434372c5d34a850337"
-        );
-        let header = provider.header_by_hash(hash).await.unwrap();
-        assert_eq!(header.hash_slow(), hash);
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_alloy_chain_provider_block_info_by_number() {
-        let mut provider = AlloyChainProvider::new(default_provider());
-        let number = provider.latest_block_number().await.unwrap();
-        let block_info = provider.block_info_by_number(number).await.unwrap();
-        assert_eq!(block_info.number, number);
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_alloy_chain_provider_receipts_by_hash() {
-        let mut provider = AlloyChainProvider::new(default_provider());
-        let hash = alloy_primitives::b256!(
-            "5224e37a8db899839e23c9fa957971cacea09295d6824a434372c5d34a850337"
-        );
-        let receipts = provider.receipts_by_hash(hash).await.unwrap();
-        assert!(!receipts.is_empty());
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn test_alloy_chain_provider_block_info_and_transactions_by_hash() {
-        let mut provider = AlloyChainProvider::new(default_provider());
-        let hash = alloy_primitives::b256!(
-            "5224e37a8db899839e23c9fa957971cacea09295d6824a434372c5d34a850337"
-        );
-        let (block_info, txs) = provider.block_info_and_transactions_by_hash(hash).await.unwrap();
-        assert_eq!(block_info.hash, hash);
-        assert!(!txs.is_empty());
-    }
-
-    #[tokio::test]
     async fn test_alloy_l2_chain_provider_latest_block_number() {
         let mut provider = AlloyL2ChainProvider::new_http(
             "https://docs-demo.quiknode.pro/".try_into().unwrap(),

--- a/crates/providers-alloy/src/alloy_providers.rs
+++ b/crates/providers-alloy/src/alloy_providers.rs
@@ -424,3 +424,89 @@ impl L2ChainProvider for AlloyL2ChainProvider {
         Ok(sys_config)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_provider() -> ReqwestProvider {
+        ReqwestProvider::new_http("https://docs-demo.quiknode.pro/".try_into().unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_alloy_chain_provider_latest_block_number() {
+        let mut provider = AlloyChainProvider::new(default_provider());
+        let number = provider.latest_block_number().await.unwrap();
+        assert!(number > 0);
+    }
+
+    #[tokio::test]
+    async fn test_alloy_chain_provider_chain_id() {
+        let mut provider = AlloyChainProvider::new(default_provider());
+        let chain_id = provider.chain_id().await.unwrap();
+        assert_eq!(chain_id, 1);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_alloy_chain_provider_header_by_hash() {
+        let mut provider = AlloyChainProvider::new(default_provider());
+        let hash = alloy_primitives::b256!(
+            "5224e37a8db899839e23c9fa957971cacea09295d6824a434372c5d34a850337"
+        );
+        let header = provider.header_by_hash(hash).await.unwrap();
+        assert_eq!(header.hash_slow(), hash);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_alloy_chain_provider_block_info_by_number() {
+        let mut provider = AlloyChainProvider::new(default_provider());
+        let number = provider.latest_block_number().await.unwrap();
+        let block_info = provider.block_info_by_number(number).await.unwrap();
+        assert_eq!(block_info.number, number);
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_alloy_chain_provider_receipts_by_hash() {
+        let mut provider = AlloyChainProvider::new(default_provider());
+        let hash = alloy_primitives::b256!(
+            "5224e37a8db899839e23c9fa957971cacea09295d6824a434372c5d34a850337"
+        );
+        let receipts = provider.receipts_by_hash(hash).await.unwrap();
+        assert!(!receipts.is_empty());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_alloy_chain_provider_block_info_and_transactions_by_hash() {
+        let mut provider = AlloyChainProvider::new(default_provider());
+        let hash = alloy_primitives::b256!(
+            "5224e37a8db899839e23c9fa957971cacea09295d6824a434372c5d34a850337"
+        );
+        let (block_info, txs) = provider.block_info_and_transactions_by_hash(hash).await.unwrap();
+        assert_eq!(block_info.hash, hash);
+        assert!(!txs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_alloy_l2_chain_provider_latest_block_number() {
+        let mut provider = AlloyL2ChainProvider::new_http(
+            "https://docs-demo.quiknode.pro/".try_into().unwrap(),
+            Arc::new(RollupConfig::default()),
+        );
+        let number = provider.latest_block_number().await.unwrap();
+        assert!(number > 0);
+    }
+
+    #[tokio::test]
+    async fn test_alloy_l2_chain_provider_chain_id() {
+        let mut provider = AlloyL2ChainProvider::new_http(
+            "https://docs-demo.quiknode.pro/".try_into().unwrap(),
+            Arc::new(RollupConfig::default()),
+        );
+        let chain_id = provider.chain_id().await.unwrap();
+        assert_eq!(chain_id, 1);
+    }
+}


### PR DESCRIPTION
### Description

Ignore codecov for alloy providers and beacon client. Tests still run in CI. We ought to still increase coverage but until a test utility exists for the inner provider type, we will see flaky results in CI.