### PR TITLE
chore: Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @clabby @refcell


### PR DESCRIPTION
### Description

Adds a `CODEOWNERS` to the repo so owners are automatically requested for review.