### PR TITLE
fix(providers): Remove Slot Derivation

### DIFF
--- a/bin/host/src/cli/mod.rs
+++ b/bin/host/src/cli/mod.rs
@@ -14,7 +14,7 @@ use clap::{
     builder::styling::{AnsiColor, Color, Style},
     ArgAction, Parser,
 };
-use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider, SimpleSlotDerivation};
+use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
 use op_alloy_genesis::RollupConfig;
 use serde::Serialize;
 use std::{path::PathBuf, sync::Arc};
@@ -130,11 +130,7 @@ impl HostCli {
     /// - A [ReqwestProvider] for the L2 node.
     pub async fn create_providers(
         &self,
-    ) -> Result<(
-        ReqwestProvider,
-        OnlineBlobProvider<OnlineBeaconClient, SimpleSlotDerivation>,
-        ReqwestProvider,
-    )> {
+    ) -> Result<(ReqwestProvider, OnlineBlobProvider<OnlineBeaconClient>, ReqwestProvider)> {
         let beacon_client = OnlineBeaconClient::new_http(
             self.l1_beacon_address.clone().ok_or(anyhow!("Beacon API URL must be set"))?,
         );

--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -14,7 +14,7 @@ use anyhow::{anyhow, Result};
 use kona_client::HintType;
 use kona_preimage::{PreimageKey, PreimageKeyType};
 use kona_primitives::IndexedBlobHash;
-use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider, SimpleSlotDerivation};
+use kona_providers_alloy::{OnlineBeaconClient, OnlineBlobProvider};
 use op_alloy_protocol::BlockInfo;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -33,7 +33,7 @@ where
     /// L1 chain provider.
     l1_provider: ReqwestProvider,
     /// The blob provider
-    blob_provider: OnlineBlobProvider<OnlineBeaconClient, SimpleSlotDerivation>,
+    blob_provider: OnlineBlobProvider<OnlineBeaconClient>,
     /// L2 chain provider.
     /// TODO: OP provider, N = Optimism
     l2_provider: ReqwestProvider,
@@ -51,7 +51,7 @@ where
     pub const fn new(
         kv_store: Arc<RwLock<KV>>,
         l1_provider: ReqwestProvider,
-        blob_provider: OnlineBlobProvider<OnlineBeaconClient, SimpleSlotDerivation>,
+        blob_provider: OnlineBlobProvider<OnlineBeaconClient>,
         l2_provider: ReqwestProvider,
         l2_head: B256,
     ) -> Self {

--- a/crates/providers-alloy/src/lib.rs
+++ b/crates/providers-alloy/src/lib.rs
@@ -25,7 +25,7 @@ pub mod prelude {
         beacon_client::{BeaconClient, OnlineBeaconClient},
         blob_provider::{
             BlobSidecarProvider, OnlineBlobProvider, OnlineBlobProviderBuilder,
-            OnlineBlobProviderWithFallback, SimpleSlotDerivation, SlotDerivation,
+            OnlineBlobProviderWithFallback,
         },
         pipeline::{new_online_pipeline, OnlinePipeline},
     };
@@ -44,5 +44,5 @@ pub use beacon_client::{BeaconClient, OnlineBeaconClient};
 pub mod blob_provider;
 pub use blob_provider::{
     BlobSidecarProvider, OnlineBlobProvider, OnlineBlobProviderBuilder,
-    OnlineBlobProviderWithFallback, SimpleSlotDerivation, SlotDerivation,
+    OnlineBlobProviderWithFallback,
 };

--- a/crates/providers-alloy/src/pipeline.rs
+++ b/crates/providers-alloy/src/pipeline.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 
 use crate::{
     AlloyChainProvider, AlloyL2ChainProvider, OnlineBeaconClient, OnlineBlobProviderWithFallback,
-    SimpleSlotDerivation,
 };
 
 /// An online derivation pipeline.
@@ -25,7 +24,7 @@ pub type OnlinePipeline =
 /// An `online` Ethereum data source.
 pub type OnlineDataProvider = EthereumDataSource<
     AlloyChainProvider,
-    OnlineBlobProviderWithFallback<OnlineBeaconClient, OnlineBeaconClient, SimpleSlotDerivation>,
+    OnlineBlobProviderWithFallback<OnlineBeaconClient, OnlineBeaconClient>,
 >;
 
 /// An `online` payload attributes builder for the `AttributesQueue` stage of the derivation
@@ -83,8 +82,7 @@ mod tests {
             rollup_config.clone(),
         );
         let beacon_client = OnlineBeaconClient::new_http("http://127.0.0.1:5555".into());
-        let blob_provider: OnlineBlobProvider<_, SimpleSlotDerivation> =
-            OnlineBlobProvider::new(beacon_client, None, None);
+        let blob_provider = OnlineBlobProvider::new(beacon_client, None, None);
         let blob_provider = OnlineBlobProviderWithFallback::new(blob_provider, None);
         let dap_source =
             EthereumDataSource::new(chain_provider.clone(), blob_provider, &rollup_config);


### PR DESCRIPTION
### Description

Removes the `SlotDerivation` trait and inlines the `SimpleSlotDerivation` method into the `OnlineBlobProvider`. If it becomes needed elsewhere, we can refactor down the road to pull it out of the `OnlineBlobProvider` into it's own type without specifying it as a generic.

### Metadata

Closes #632 