### PR TITLE
chore(mpt): mpt noop trait impls

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -25,6 +25,7 @@ ignore:
   - "bin/"
   - "crates/providers-alloy/src/alloy_providers.rs"  # Flaky testing with online providers
   - "crates/providers-alloy/src/beacon_client.rs"  # Flaky testing with online providers
+  - "crates/mpt/src/noop.rs" # Uncovered noop implementations used downstream and by tests
 
 # Make comments less noisy
 comment:

--- a/crates/mpt/src/fetcher.rs
+++ b/crates/mpt/src/fetcher.rs
@@ -1,7 +1,7 @@
 //! Contains the [TrieProvider] trait for fetching trie node preimages, contract bytecode, and
 //! headers.
 
-use alloc::string::{String, ToString};
+use alloc::string::ToString;
 use alloy_consensus::Header;
 use alloy_primitives::{Address, Bytes, B256, U256};
 use core::fmt::Display;
@@ -92,49 +92,4 @@ pub trait TrieHinter {
         slot: U256,
         block_number: u64,
     ) -> Result<(), Self::Error>;
-}
-
-/// The default, no-op implementation of the [TrieProvider] trait, used for testing.
-#[derive(Debug, Clone, Copy)]
-pub struct NoopTrieProvider;
-
-impl TrieProvider for NoopTrieProvider {
-    type Error = String;
-
-    fn trie_node_preimage(&self, _key: B256) -> Result<Bytes, Self::Error> {
-        Ok(Bytes::new())
-    }
-
-    fn bytecode_by_hash(&self, _code_hash: B256) -> Result<Bytes, Self::Error> {
-        Ok(Bytes::new())
-    }
-
-    fn header_by_hash(&self, _hash: B256) -> Result<Header, Self::Error> {
-        Ok(Header::default())
-    }
-}
-
-/// The default, no-op implementation of the [TrieHinter] trait, used for testing.
-#[derive(Debug, Clone, Copy)]
-pub struct NoopTrieHinter;
-
-impl TrieHinter for NoopTrieHinter {
-    type Error = String;
-
-    fn hint_trie_node(&self, _hash: B256) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn hint_account_proof(&self, _address: Address, _block_number: u64) -> Result<(), Self::Error> {
-        Ok(())
-    }
-
-    fn hint_storage_proof(
-        &self,
-        _address: Address,
-        _slot: U256,
-        _block_number: u64,
-    ) -> Result<(), Self::Error> {
-        Ok(())
-    }
 }

--- a/crates/mpt/src/lib.rs
+++ b/crates/mpt/src/lib.rs
@@ -19,13 +19,16 @@ pub use errors::{
 };
 
 mod fetcher;
-pub use fetcher::{NoopTrieHinter, NoopTrieProvider, TrieHinter, TrieProvider};
+pub use fetcher::{TrieHinter, TrieProvider};
 
 mod node;
 pub use node::TrieNode;
 
 mod list_walker;
 pub use list_walker::OrderedListWalker;
+
+mod noop;
+pub use noop::{NoopTrieHinter, NoopTrieProvider};
 
 mod util;
 pub use util::ordered_trie_with_encoder;

--- a/crates/mpt/src/node.rs
+++ b/crates/mpt/src/node.rs
@@ -684,7 +684,7 @@ impl Decodable for TrieNode {
 mod test {
     use super::*;
     use crate::{
-        fetcher::NoopTrieProvider, ordered_trie_with_encoder, test_util::TrieNodeProvider,
+        NoopTrieProvider, ordered_trie_with_encoder, test_util::TrieNodeProvider,
         NoopTrieHinter, TrieNode,
     };
     use alloc::{collections::BTreeMap, vec, vec::Vec};

--- a/crates/mpt/src/node.rs
+++ b/crates/mpt/src/node.rs
@@ -684,8 +684,8 @@ impl Decodable for TrieNode {
 mod test {
     use super::*;
     use crate::{
-        NoopTrieProvider, ordered_trie_with_encoder, test_util::TrieNodeProvider,
-        NoopTrieHinter, TrieNode,
+        ordered_trie_with_encoder, test_util::TrieNodeProvider, NoopTrieHinter, NoopTrieProvider,
+        TrieNode,
     };
     use alloc::{collections::BTreeMap, vec, vec::Vec};
     use alloy_primitives::{b256, bytes, hex, keccak256};

--- a/crates/mpt/src/noop.rs
+++ b/crates/mpt/src/noop.rs
@@ -1,10 +1,10 @@
 //! Trait implementations for `kona-mpt` traits that are effectively a no-op.
 //! Providers trait implementations for downstream users who do not require hinting.
 
+use crate::{TrieHinter, TrieProvider};
 use alloc::string::String;
 use alloy_consensus::Header;
 use alloy_primitives::{Address, Bytes, B256, U256};
-use crate::{TrieHinter, TrieProvider};
 
 /// The default, no-op implementation of the [TrieProvider] trait, used for testing.
 #[derive(Debug, Clone, Copy)]

--- a/crates/mpt/src/noop.rs
+++ b/crates/mpt/src/noop.rs
@@ -1,0 +1,52 @@
+//! Trait implementations for `kona-mpt` traits that are effectively a no-op.
+//! Providers trait implementations for downstream users who do not require hinting.
+
+use alloc::string::String;
+use alloy_consensus::Header;
+use alloy_primitives::{Address, Bytes, B256, U256};
+use crate::{TrieHinter, TrieProvider};
+
+/// The default, no-op implementation of the [TrieProvider] trait, used for testing.
+#[derive(Debug, Clone, Copy)]
+pub struct NoopTrieProvider;
+
+impl TrieProvider for NoopTrieProvider {
+    type Error = String;
+
+    fn trie_node_preimage(&self, _key: B256) -> Result<Bytes, Self::Error> {
+        Ok(Bytes::new())
+    }
+
+    fn bytecode_by_hash(&self, _code_hash: B256) -> Result<Bytes, Self::Error> {
+        Ok(Bytes::new())
+    }
+
+    fn header_by_hash(&self, _hash: B256) -> Result<Header, Self::Error> {
+        Ok(Header::default())
+    }
+}
+
+/// The default, no-op implementation of the [TrieHinter] trait, used for testing.
+#[derive(Debug, Clone, Copy)]
+pub struct NoopTrieHinter;
+
+impl TrieHinter for NoopTrieHinter {
+    type Error = String;
+
+    fn hint_trie_node(&self, _hash: B256) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn hint_account_proof(&self, _address: Address, _block_number: u64) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn hint_storage_proof(
+        &self,
+        _address: Address,
+        _slot: U256,
+        _block_number: u64,
+    ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Description

Moves noop impls into a `noop.rs` module that is now ignored by codecov.

Replaces #645