### PR TITLE
chore(derive): Channel Bank Reset Test Coverage

### DIFF
--- a/crates/derive/src/stages/channel_bank.rs
+++ b/crates/derive/src/stages/channel_bank.rs
@@ -311,6 +311,22 @@ mod tests {
         assert_eq!(err, PipelineError::MissingOrigin.crit());
     }
 
+    #[tokio::test]
+    async fn test_reset() {
+        let mock = MockChannelBankProvider::new(vec![]);
+        let cfg = Arc::new(RollupConfig::default());
+        let mut channel_bank = ChannelBank::new(cfg, mock);
+        channel_bank.channels.insert([0xFF; 16], Channel::default());
+        channel_bank.channel_queue.push_back([0xFF; 16]);
+        let block_info = BlockInfo::default();
+        let system_config = SystemConfig::default();
+        assert!(!channel_bank.prev.reset);
+        channel_bank.reset(block_info, &system_config).await.unwrap();
+        assert_eq!(channel_bank.channels.len(), 0);
+        assert_eq!(channel_bank.channel_queue.len(), 0);
+        assert!(channel_bank.prev.reset);
+    }
+
     #[test]
     fn test_ingest_invalid_frame() {
         let trace_store: TraceStorage = Default::default();

--- a/crates/derive/src/stages/test_utils/channel_bank.rs
+++ b/crates/derive/src/stages/test_utils/channel_bank.rs
@@ -17,12 +17,14 @@ pub struct MockChannelBankProvider {
     pub data: Vec<PipelineResult<Frame>>,
     /// The block info
     pub block_info: Option<BlockInfo>,
+    /// Tracks if the channel bank provider has been reset.
+    pub reset: bool,
 }
 
 impl MockChannelBankProvider {
     /// Creates a new [MockChannelBankProvider] with the given data.
     pub fn new(data: Vec<PipelineResult<Frame>>) -> Self {
-        Self { data, block_info: Some(BlockInfo::default()) }
+        Self { data, block_info: Some(BlockInfo::default()), reset: false }
     }
 }
 
@@ -53,6 +55,7 @@ impl ChannelBankProvider for MockChannelBankProvider {
 #[async_trait]
 impl ResettableStage for MockChannelBankProvider {
     async fn reset(&mut self, _base: BlockInfo, _cfg: &SystemConfig) -> PipelineResult<()> {
+        self.reset = true;
         Ok(())
     }
 }


### PR DESCRIPTION
### Description

Adds test coverage over the channel bank reset.