### PR TITLE
chore(derive): Test ChannelReader Flushing

### DIFF
--- a/crates/derive/src/stages/channel_reader.rs
+++ b/crates/derive/src/stages/channel_reader.rs
@@ -265,6 +265,15 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_flush_channel_reader() {
+        let mock = MockChannelReaderProvider::new(vec![Ok(Some(new_compressed_batch_data()))]);
+        let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));
+        reader.next_batch = Some(BatchReader::from(new_compressed_batch_data()));
+        reader.flush_channel().await.unwrap();
+        assert!(reader.next_batch.is_none());
+    }
+
+    #[tokio::test]
     async fn test_next_batch_batch_reader_set_fails() {
         let mock = MockChannelReaderProvider::new(vec![Err(PipelineError::Eof.temp())]);
         let mut reader = ChannelReader::new(mock, Arc::new(RollupConfig::default()));


### PR DESCRIPTION
### Description

Small PR to add test coverage over the `ChannelReader` flushes.