### PR TITLE
chore(client): Improve `BootInfo` field names

### DIFF
--- a/bin/client/src/boot.rs
+++ b/bin/client/src/boot.rs
@@ -31,22 +31,22 @@ pub const L2_ROLLUP_CONFIG_KEY: U256 = U256::from_be_slice(&[6]);
 /// **Verified inputs:**
 /// - `l1_head`: The L1 head hash containing the safe L2 chain data that may reproduce the L2 head
 ///   hash.
-/// - `l2_output_root`: The latest finalized L2 output root.
+/// - `agreed_l2_output_root`:The agreed upon safe L2 output root.
 /// - `chain_id`: The L2 chain ID.
 ///
 /// **User submitted inputs:**
-/// - `l2_claim`: The L2 output root claim.
-/// - `l2_claim_block`: The L2 claim block number.
+/// - `claimed_l2_output_root`: The L2 output root claim.
+/// - `claimed_l2_block_number`: The L2 claim block number.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BootInfo {
     /// The L1 head hash containing the safe L2 chain data that may reproduce the L2 head hash.
     pub l1_head: B256,
-    /// The latest finalized L2 output root.
-    pub l2_output_root: B256,
+    /// The agreed upon safe L2 output root.
+    pub agreed_l2_output_root: B256,
     /// The L2 output root claim.
-    pub l2_claim: B256,
+    pub claimed_l2_output_root: B256,
     /// The L2 claim block number.
-    pub l2_claim_block: u64,
+    pub claimed_l2_block_number: u64,
     /// The L2 chain ID.
     pub chain_id: u64,
     /// The rollup config for the L2 chain.
@@ -107,6 +107,13 @@ impl BootInfo {
                 .map_err(|e| anyhow!("Failed to deserialize rollup config: {}", e))?
         };
 
-        Ok(Self { l1_head, l2_output_root, l2_claim, l2_claim_block, chain_id, rollup_config })
+        Ok(Self {
+            l1_head,
+            agreed_l2_output_root: l2_output_root,
+            claimed_l2_output_root: l2_claim,
+            claimed_l2_block_number: l2_claim_block,
+            chain_id,
+            rollup_config,
+        })
     }
 }

--- a/bin/client/src/kona.rs
+++ b/bin/client/src/kona.rs
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
         //                          EPILOGUE                          //
         ////////////////////////////////////////////////////////////////
 
-        if number != boot.l2_claim_block || output_root != boot.l2_claim {
+        if number != boot.claimed_l2_block_number || output_root != boot.claimed_l2_output_root {
             tracing::error!(
                 target: "client",
                 "Failed to validate L2 block #{number} with output root {output_root}",

--- a/bin/client/src/l1/driver.rs
+++ b/bin/client/src/l1/driver.rs
@@ -297,12 +297,15 @@ where
     ) -> Result<(BlockInfo, L2BlockInfo, Sealed<Header>)> {
         // Find the initial safe head, based off of the starting L2 block number in the boot info.
         caching_oracle
-            .write(&HintType::StartingL2Output.encode_with(&[boot_info.l2_output_root.as_ref()]))
+            .write(
+                &HintType::StartingL2Output
+                    .encode_with(&[boot_info.agreed_l2_output_root.as_ref()]),
+            )
             .await?;
         let mut output_preimage = [0u8; 128];
         caching_oracle
             .get_exact(
-                PreimageKey::new(*boot_info.l2_output_root, PreimageKeyType::Keccak256),
+                PreimageKey::new(*boot_info.agreed_l2_output_root, PreimageKeyType::Keccak256),
                 &mut output_preimage,
             )
             .await?;

--- a/bin/client/src/l2/chain_provider.rs
+++ b/bin/client/src/l2/chain_provider.rs
@@ -38,12 +38,16 @@ impl<T: CommsClient> OracleL2ChainProvider<T> {
         // Fetch the starting L2 output preimage.
         self.oracle
             .write(
-                &HintType::StartingL2Output.encode_with(&[self.boot_info.l2_output_root.as_ref()]),
+                &HintType::StartingL2Output
+                    .encode_with(&[self.boot_info.agreed_l2_output_root.as_ref()]),
             )
             .await?;
         let output_preimage = self
             .oracle
-            .get(PreimageKey::new(*self.boot_info.l2_output_root, PreimageKeyType::Keccak256))
+            .get(PreimageKey::new(
+                *self.boot_info.agreed_l2_output_root,
+                PreimageKeyType::Keccak256,
+            ))
             .await?;
 
         // Fetch the starting block header.


### PR DESCRIPTION
## Overview

Improves the names of the fields within `BootInfo` for clarity.