### PR TITLE
chore(host): Improve CLI flag naming

### DIFF
--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -17,16 +17,16 @@ run-client-asterisc block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc ver
   CLIENT_BIN_PATH="./target/riscv64gc-unknown-none-elf/release-client-lto/kona"
   STATE_PATH="./state.json"
 
-  L2_BLOCK_NUMBER={{block_number}}
-  echo "Fetching configuration for block #$L2_BLOCK_NUMBER..."
+  CLAIMED_L2_BLOCK_NUMBER={{block_number}}
+  echo "Fetching configuration for block #$CLAIMED_L2_BLOCK_NUMBER..."
 
   # Get output root for block
-  L2_CLAIM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $L2_BLOCK_NUMBER) | jq -r .outputRoot)
+  CLAIMED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $CLAIMED_L2_BLOCK_NUMBER) | jq -r .outputRoot)
 
   # Get the info for the previous block
-  L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((L2_BLOCK_NUMBER - 1))) | jq -r .outputRoot)
-  L2_HEAD=$(cast block --rpc-url $L2_NODE_ADDRESS $((L2_BLOCK_NUMBER - 1)) -j | jq -r .hash)
-  L1_ORIGIN_NUM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((L2_BLOCK_NUMBER - 1))) | jq -r .blockRef.l1origin.number)
+  AGREED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .outputRoot)
+  AGREED_L2_HEAD_HASH=$(cast block --rpc-url $L2_NODE_ADDRESS $((CLAIMED_L2_BLOCK_NUMBER - 1)) -j | jq -r .hash)
+  L1_ORIGIN_NUM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .blockRef.l1origin.number)
   L1_HEAD=$(cast block --rpc-url $L1_NODE_ADDRESS $((L1_ORIGIN_NUM + 30)) -j | jq -r .hash)
   L2_CHAIN_ID=$(cast chain-id --rpc-url $L2_NODE_ADDRESS)
 
@@ -50,10 +50,10 @@ run-client-asterisc block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc ver
     -- \
     $HOST_BIN_PATH \
     --l1-head $L1_HEAD \
-    --l2-head $L2_HEAD \
-    --l2-claim $L2_CLAIM \
-    --l2-output-root $L2_OUTPUT_ROOT \
-    --l2-block-number $L2_BLOCK_NUMBER \
+    --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
+    --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
+    --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
+    --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
     --l2-chain-id $L2_CHAIN_ID \
     --l1-node-address $L1_NODE_ADDRESS \
     --l1-beacon-address $L1_BEACON_ADDRESS \
@@ -71,16 +71,16 @@ run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbo
   L2_NODE_ADDRESS="{{l2_rpc}}"
   OP_NODE_ADDRESS="{{rollup_node_rpc}}"
 
-  L2_BLOCK_NUMBER={{block_number}}
-  echo "Fetching configuration for block #$L2_BLOCK_NUMBER..."
+  CLAIMED_L2_BLOCK_NUMBER={{block_number}}
+  echo "Fetching configuration for block #$CLAIMED_L2_BLOCK_NUMBER..."
 
   # Get output root for block
-  L2_CLAIM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $L2_BLOCK_NUMBER) | jq -r .outputRoot)
+  CLAIMED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $CLAIMED_L2_BLOCK_NUMBER) | jq -r .outputRoot)
 
   # Get the info for the previous block
-  L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((L2_BLOCK_NUMBER - 1))) | jq -r .outputRoot)
-  L2_HEAD=$(cast block --rpc-url $L2_NODE_ADDRESS $((L2_BLOCK_NUMBER - 1)) -j | jq -r .hash)
-  L1_ORIGIN_NUM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((L2_BLOCK_NUMBER - 1))) | jq -r .blockRef.l1origin.number)
+  AGREED_L2_OUTPUT_ROOT=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .outputRoot)
+  AGREED_L2_HEAD_HASH=$(cast block --rpc-url $L2_NODE_ADDRESS $((CLAIMED_L2_BLOCK_NUMBER - 1)) -j | jq -r .hash)
+  L1_ORIGIN_NUM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .blockRef.l1origin.number)
   L1_HEAD=$(cast block --rpc-url $L1_NODE_ADDRESS $((L1_ORIGIN_NUM + 30)) -j | jq -r .hash)
   L2_CHAIN_ID=$(cast chain-id --rpc-url $L2_NODE_ADDRESS)
 
@@ -94,10 +94,10 @@ run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbo
   echo "Running host program with native client program..."
   cargo r --bin kona-host --release -- \
     --l1-head $L1_HEAD \
-    --l2-head $L2_HEAD \
-    --l2-claim $L2_CLAIM \
-    --l2-output-root $L2_OUTPUT_ROOT \
-    --l2-block-number $L2_BLOCK_NUMBER \
+    --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
+    --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
+    --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
+    --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
     --l2-chain-id $L2_CHAIN_ID \
     --l1-node-address $L1_NODE_ADDRESS \
     --l1-beacon-address $L1_BEACON_ADDRESS \
@@ -112,10 +112,10 @@ run-client-native-offline block_number l2_claim l2_output_root l2_head l1_head l
 
   CLIENT_BIN_PATH="./target/release-client-lto/kona"
 
-  L2_BLOCK_NUMBER={{block_number}}
-  L2_CLAIM={{l2_claim}}
-  L2_OUTPUT_ROOT={{l2_output_root}}
-  L2_HEAD={{l2_head}}
+  CLAIMED_L2_BLOCK_NUMBER={{block_number}}
+  CLAIMED_L2_OUTPUT_ROOT={{l2_claim}}
+  AGREED_L2_OUTPUT_ROOT={{l2_output_root}}
+  AGREED_L2_HEAD_HASH={{l2_head}}
   L1_HEAD={{l1_head}}
   L2_CHAIN_ID={{l2_chain_id}}
 
@@ -127,10 +127,10 @@ run-client-native-offline block_number l2_claim l2_output_root l2_head l1_head l
   echo "Running host program with native client program..."
   cargo r --bin kona-host --release -- \
     --l1-head $L1_HEAD \
-    --l2-head $L2_HEAD \
-    --l2-claim $L2_CLAIM \
-    --l2-output-root $L2_OUTPUT_ROOT \
-    --l2-block-number $L2_BLOCK_NUMBER \
+    --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
+    --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
+    --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
+    --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
     --l2-chain-id $L2_CHAIN_ID \
     --exec $CLIENT_BIN_PATH \
     --data-dir ./data \
@@ -144,10 +144,10 @@ run-client-asterisc-offline block_number l2_claim l2_output_root l2_head l1_head
   CLIENT_BIN_PATH="./target/riscv64gc-unknown-none-elf/release-client-lto/kona"
   STATE_PATH="./state.json"
 
-  L2_BLOCK_NUMBER={{block_number}}
-  L2_CLAIM={{l2_claim}}
-  L2_OUTPUT_ROOT={{l2_output_root}}
-  L2_HEAD={{l2_head}}
+  CLAIMED_L2_BLOCK_NUMBER={{block_number}}
+  CLAIMED_L2_OUTPUT_ROOT={{l2_claim}}
+  AGREED_L2_OUTPUT_ROOT={{l2_output_root}}
+  AGREED_L2_HEAD_HASH={{l2_head}}
   L1_HEAD={{l1_head}}
   L2_CHAIN_ID={{l2_chain_id}}
 
@@ -171,10 +171,10 @@ run-client-asterisc-offline block_number l2_claim l2_output_root l2_head l1_head
     -- \
     $HOST_BIN_PATH \
     --l1-head $L1_HEAD \
-    --l2-head $L2_HEAD \
-    --l2-claim $L2_CLAIM \
-    --l2-output-root $L2_OUTPUT_ROOT \
-    --l2-block-number $L2_BLOCK_NUMBER \
+    --agreed-l2-head-hash $AGREED_L2_HEAD_HASH \
+    --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
+    --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
+    --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
     --l2-chain-id $L2_CHAIN_ID \
     --server \
     --data-dir ./data \

--- a/bin/host/src/cli/mod.rs
+++ b/bin/host/src/cli/mod.rs
@@ -44,18 +44,18 @@ pub struct HostCli {
     /// Hash of the L1 head block. Derivation stops after this block is processed.
     #[clap(long, value_parser = parse_b256)]
     pub l1_head: B256,
-    /// Hash of the L2 block committed to by `--l2-output-root`.
-    #[clap(long, value_parser = parse_b256)]
-    pub l2_head: B256,
-    /// Agreed L2 Output Root to start derivation from.
-    #[clap(long, value_parser = parse_b256)]
-    pub l2_output_root: B256,
-    /// Claimed L2 output root at block # `--l2-block-number` to validate.
-    #[clap(long, value_parser = parse_b256)]
-    pub l2_claim: B256,
-    /// Number of the L2 block that the claim commits to.
-    #[clap(long)]
-    pub l2_block_number: u64,
+    /// Hash of the agreed upon safe L2 block committed to by `--agreed-l2-output-root`.
+    #[clap(long, visible_alias = "l2-head", value_parser = parse_b256)]
+    pub agreed_l2_head_hash: B256,
+    /// Agreed safe L2 Output Root to start derivation from.
+    #[clap(long, visible_alias = "l2-output-root", value_parser = parse_b256)]
+    pub agreed_l2_output_root: B256,
+    /// Claimed L2 output root at block # `--claimed-l2-block-number` to validate.
+    #[clap(long, visible_alias = "l2-claim", value_parser = parse_b256)]
+    pub claimed_l2_output_root: B256,
+    /// Number of the L2 block that the claimed output root commits to.
+    #[clap(long, visible_alias = "l2-block-number")]
+    pub claimed_l2_block_number: u64,
     /// Address of L2 JSON-RPC endpoint to use (eth and debug namespace required).
     #[clap(
         long,

--- a/bin/host/src/kv/local.rs
+++ b/bin/host/src/kv/local.rs
@@ -31,9 +31,11 @@ impl KeyValueStore for LocalKeyValueStore {
         let preimage_key = PreimageKey::try_from(*key).ok()?;
         match preimage_key.key_value() {
             L1_HEAD_KEY => Some(self.cfg.l1_head.to_vec()),
-            L2_OUTPUT_ROOT_KEY => Some(self.cfg.l2_output_root.to_vec()),
-            L2_CLAIM_KEY => Some(self.cfg.l2_claim.to_vec()),
-            L2_CLAIM_BLOCK_NUMBER_KEY => Some(self.cfg.l2_block_number.to_be_bytes().to_vec()),
+            L2_OUTPUT_ROOT_KEY => Some(self.cfg.agreed_l2_output_root.to_vec()),
+            L2_CLAIM_KEY => Some(self.cfg.claimed_l2_output_root.to_vec()),
+            L2_CLAIM_BLOCK_NUMBER_KEY => {
+                Some(self.cfg.claimed_l2_block_number.to_be_bytes().to_vec())
+            }
             L2_CHAIN_ID_KEY => {
                 Some(self.cfg.l2_chain_id.unwrap_or(DEFAULT_CHAIN_ID).to_be_bytes().to_vec())
             }

--- a/bin/host/src/lib.rs
+++ b/bin/host/src/lib.rs
@@ -48,7 +48,7 @@ pub async fn start_server(cfg: HostCli) -> Result<()> {
             l1_provider,
             blob_provider,
             l2_provider,
-            cfg.l2_head,
+            cfg.agreed_l2_head_hash,
         ))))
     } else {
         None
@@ -86,7 +86,7 @@ pub async fn start_server_and_native_client(cfg: HostCli) -> Result<i32> {
             l1_provider,
             blob_provider,
             l2_provider,
-            cfg.l2_head,
+            cfg.agreed_l2_head_hash,
         ))))
     } else {
         None


### PR DESCRIPTION
## Overview

Improves the names of the CLI flags in `kona-host`. Old CLI flags are still retained as aliases for backwards compatibility with existing scripts that execute `kona-host`, i.e. for OP succinct and in the op-challenger.