### PR TITLE
chore(ci): Reduce monorepo auto-update frequency

### DIFF
--- a/.github/workflows/monorepo_pin_update.yaml
+++ b/.github/workflows/monorepo_pin_update.yaml
@@ -2,7 +2,7 @@ name: Update the monorepo pin commit
 
 on:
   schedule:
-    - cron:  '30 5 */2 * *'
+    - cron:  '30 5 */14 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/monorepo_pin_update.yaml
+++ b/.github/workflows/monorepo_pin_update.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }} 
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
       - name: Update Monorepo Commit 
@@ -23,7 +23,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update Monorepo Commit
           signoff: false
           branch: bot/update-monorepo


### PR DESCRIPTION
## Overview

Reduces the frequency of the `monorepo` update auto-PR to once every 14 days. Right now it fires off every 2 days, which isn't really needed. The action tests don't update that frequently.

also moves to use the repository secret for posting PRs, similar to the `release-plz` workflow