### PR TITLE
fix(derive): Retain L1 blocks

### DIFF
--- a/crates/derive/src/stages/batch_queue.rs
+++ b/crates/derive/src/stages/batch_queue.rs
@@ -481,7 +481,6 @@ where
 {
     async fn flush_channel(&mut self) -> PipelineResult<()> {
         self.batches.clear();
-        self.l1_blocks.clear();
         self.next_spans.clear();
         self.prev.flush_channel().await
     }
@@ -567,7 +566,7 @@ mod tests {
         bq.flush_channel().await.unwrap();
         assert!(bq.prev.flushed);
         assert!(bq.batches.is_empty());
-        assert!(bq.l1_blocks.is_empty());
+        assert!(!bq.l1_blocks.is_empty());
         assert!(bq.next_spans.is_empty());
     }
 


### PR DESCRIPTION
## Overview

Retains `l1_blocks` in the `BatchQueue` when flushing. We cannot flush this list at will, and instead have to have these L1 origins consumed as the sequencer epoch advances.