### PR TITLE
chore: Removes the last TODO

### DIFF
--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -35,7 +35,6 @@ where
     /// The blob provider
     blob_provider: OnlineBlobProvider<OnlineBeaconClient>,
     /// L2 chain provider.
-    /// TODO: OP provider, N = Optimism
     l2_provider: ReqwestProvider,
     /// L2 head
     l2_head: B256,


### PR DESCRIPTION
### Description

Micro-pr to remove the last `// TODO:` comment.