### PR TITLE
fix(mpt): Empty root node case

### DIFF
--- a/crates/mpt/src/node.rs
+++ b/crates/mpt/src/node.rs
@@ -109,7 +109,7 @@ impl TrieNode {
     }
 
     /// Returns the commitment of a [TrieNode::Blinded] node, if `self` is of the
-    /// [TrieNode::Blinded] variant.
+    /// [TrieNode::Blinded] or [TrieNode::Empty] variants.
     ///
     /// ## Returns
     /// - `Some(B256)` - The commitment of the blinded node
@@ -117,6 +117,7 @@ impl TrieNode {
     pub const fn blinded_commitment(&self) -> Option<B256> {
         match self {
             Self::Blinded { commitment } => Some(*commitment),
+            Self::Empty => Some(EMPTY_ROOT_HASH),
             _ => None,
         }
     }
@@ -680,6 +681,12 @@ mod test {
     use alloy_rlp::{Decodable, Encodable, EMPTY_STRING_CODE};
     use alloy_trie::{HashBuilder, Nibbles};
     use rand::prelude::SliceRandom;
+
+    #[test]
+    fn test_empty_blinded() {
+        let trie_node = TrieNode::Empty;
+        assert_eq!(trie_node.blinded_commitment().unwrap(), EMPTY_ROOT_HASH);
+    }
 
     #[test]
     fn test_decode_branch() {


### PR DESCRIPTION
## Overview

Adds coverage for the case where the root node of an MPT is the empty root hash. The previous behavior could cause a bug if an account storage root was cleared out entirely from a previously populated value during the execution of a block.

This ensures that, if the root is empty, the empty root hash is returned by `blinded_commitment`.

closes #704 