### PR TITLE
fix(providers-alloy): Recycle Beacon Types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
  "foldhash",
  "hashbrown 0.15.0",
  "hex-literal",
- "indexmap",
+ "indexmap 2.6.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -321,6 +321,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-types-beacon"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b535781fe224c101c3d957b514cb9f438d165ff0280e5c0b2f87a0d9a2950593"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rpc-types-engine",
+ "serde",
+ "serde_with",
+ "thiserror 1.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "alloy-rpc-types-engine"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,7 +417,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap",
+ "indexmap 2.6.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -486,6 +500,21 @@ dependencies = [
  "nybbles",
  "smallvec",
  "tracing",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -998,6 +1027,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1286,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1351,16 @@ checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -1673,7 +1760,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1689,6 +1776,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1869,6 +1962,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +2022,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
@@ -1917,7 +2050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash",
- "indexmap",
+ "indexmap 2.6.0",
  "is-terminal",
  "itoa",
  "log",
@@ -2248,6 +2381,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-client",
+ "alloy-rpc-types-beacon",
  "alloy-serde",
  "alloy-transport",
  "alloy-transport-http",
@@ -2529,6 +2663,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-format"
@@ -2922,6 +3062,12 @@ checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pprof"
@@ -3417,7 +3563,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.14.5",
- "indexmap",
+ "indexmap 2.6.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -3748,7 +3894,7 @@ version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbcf9b78a125ee667ae19388837dd12294b858d101fdd393cb9d5501ef09eb2"
 dependencies = [
- "indexmap",
+ "indexmap 2.6.0",
  "itoa",
  "memchr",
  "ryu",
@@ -3776,6 +3922,36 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.6.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4137,6 +4313,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,7 +4464,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.6.0",
  "toml_datetime",
  "winnow",
 ]
@@ -4622,6 +4829,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ alloy-rpc-client = { version = "0.5.0", default-features = false }
 alloy-node-bindings = { version = "0.5.0", default-features = false }
 alloy-transport-http = { version = "0.5.0", default-features = false }
 alloy-rpc-types-engine = { version = "0.5.0", default-features = false }
+alloy-rpc-types-beacon = { version = "0.5.0", default-features = false }
 
 # General
 anyhow = { version = "1.0.89", default-features = false }

--- a/crates/providers-alloy/Cargo.toml
+++ b/crates/providers-alloy/Cargo.toml
@@ -19,6 +19,7 @@ alloy-provider = { workspace = true, features = ["reqwest"] }
 alloy-rlp = { workspace = true, features = ["derive"] }
 alloy-consensus = { workspace = true, features = ["k256", "serde", "std"] }
 alloy-primitives = { workspace = true, features = ["rlp", "k256", "serde"] }
+alloy-rpc-types-beacon.workspace = true
 
 # OP Alloy
 op-alloy-consensus = { workspace = true, features = ["k256"] }

--- a/crates/providers-alloy/src/blob_provider.rs
+++ b/crates/providers-alloy/src/blob_provider.rs
@@ -1,9 +1,9 @@
 //! Contains an online implementation of the `BlobProvider` trait.
 
 use alloy_eips::eip4844::{Blob, BlobTransactionSidecarItem};
+use alloy_rpc_types_beacon::sidecar::BlobData;
 use async_trait::async_trait;
 use kona_derive::{errors::BlobProviderError, sources::IndexedBlobHash, traits::BlobProvider};
-use alloy_rpc_types_beacon::sidecar::BlobData;
 use op_alloy_protocol::BlockInfo;
 use tracing::warn;
 
@@ -109,7 +109,15 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
             return Err(BlobProviderError::SidecarLengthMismatch(blob_hashes.len(), filtered.len()));
         }
 
-        Ok(filtered.into_iter().map(|s| s.into()).collect::<Vec<BlobTransactionSidecarItem>>())
+        Ok(filtered
+            .into_iter()
+            .map(|s| BlobTransactionSidecarItem {
+                index: s.index,
+                blob: s.blob,
+                kzg_commitment: s.kzg_commitment,
+                kzg_proof: s.kzg_proof,
+            })
+            .collect::<Vec<BlobTransactionSidecarItem>>())
     }
 }
 
@@ -272,7 +280,15 @@ impl<B: BeaconClient, F: BlobSidecarProvider> OnlineBlobProviderWithFallback<B, 
             return Err(BlobProviderError::SidecarLengthMismatch(blob_hashes.len(), filtered.len()));
         }
 
-        Ok(filtered.into_iter().map(|s| s.inner).collect::<Vec<BlobTransactionSidecarItem>>())
+        Ok(filtered
+            .into_iter()
+            .map(|s| BlobTransactionSidecarItem {
+                index: s.index,
+                blob: s.blob,
+                kzg_commitment: s.kzg_commitment,
+                kzg_proof: s.kzg_proof,
+            })
+            .collect::<Vec<BlobTransactionSidecarItem>>())
     }
 }
 
@@ -441,11 +457,12 @@ impl<B: BeaconClient, F: BlobSidecarProvider> From<OnlineBlobProviderBuilder<B, 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_rpc_types_beacon::sidecar::BeaconBlobBundle;
-    use crate::{
-        test_utils::MockBeaconClient, APIConfigResponse, APIGenesisResponse,
-    };
+    use crate::{test_utils::MockBeaconClient, APIConfigResponse, APIGenesisResponse};
     use alloy_primitives::b256;
+    use alloy_rpc_types_beacon::{
+        header::{BeaconBlockHeader, Header},
+        sidecar::BeaconBlobBundle,
+    };
 
     #[test]
     fn test_build_online_provider_with_fallback() {
@@ -604,7 +621,23 @@ mod tests {
             beacon_genesis: Some(APIGenesisResponse::new(10)),
             config_spec: Some(APIConfigResponse::new(12)),
             blob_sidecars: Some(BeaconBlobBundle {
-                data: vec![BlobData::default()],
+                data: vec![BlobData {
+                    index: 0,
+                    blob: Box::new(Blob::default()),
+                    kzg_commitment: Default::default(),
+                    kzg_proof: Default::default(),
+                    signed_block_header: Header {
+                        message: BeaconBlockHeader {
+                            slot: 0,
+                            proposer_index: 0,
+                            parent_root: Default::default(),
+                            state_root: Default::default(),
+                            body_root: Default::default(),
+                        },
+                        signature: Default::default(),
+                    },
+                    kzg_commitment_inclusion_proof: Default::default(),
+                }],
             }),
             ..Default::default()
         };
@@ -666,8 +699,21 @@ mod tests {
             config_spec: Some(APIConfigResponse::new(12)),
             blob_sidecars: Some(BeaconBlobBundle {
                 data: vec![BlobData {
-                    inner: BlobTransactionSidecarItem::default(),
-                    ..Default::default()
+                    index: 0,
+                    blob: Box::new(Blob::default()),
+                    kzg_commitment: Default::default(),
+                    kzg_proof: Default::default(),
+                    signed_block_header: Header {
+                        message: BeaconBlockHeader {
+                            slot: 0,
+                            proposer_index: 0,
+                            parent_root: Default::default(),
+                            state_root: Default::default(),
+                            body_root: Default::default(),
+                        },
+                        signature: Default::default(),
+                    },
+                    kzg_commitment_inclusion_proof: Default::default(),
                 }],
             }),
             ..Default::default()
@@ -689,8 +735,21 @@ mod tests {
             config_spec: Some(APIConfigResponse::new(12)),
             blob_sidecars: Some(BeaconBlobBundle {
                 data: vec![BlobData {
-                    inner: BlobTransactionSidecarItem::default(),
-                    ..Default::default()
+                    index: 0,
+                    blob: Box::new(Blob::default()),
+                    kzg_commitment: Default::default(),
+                    kzg_proof: Default::default(),
+                    signed_block_header: Header {
+                        message: BeaconBlockHeader {
+                            slot: 0,
+                            proposer_index: 0,
+                            parent_root: Default::default(),
+                            state_root: Default::default(),
+                            body_root: Default::default(),
+                        },
+                        signature: Default::default(),
+                    },
+                    kzg_commitment_inclusion_proof: Default::default(),
                 }],
             }),
             ..Default::default()

--- a/crates/providers-alloy/src/lib.rs
+++ b/crates/providers-alloy/src/lib.rs
@@ -39,10 +39,7 @@ pub mod alloy_providers;
 pub use alloy_providers::{AlloyChainProvider, AlloyL2ChainProvider};
 
 pub mod beacon_client;
-pub use beacon_client::{
-    APIBlobSidecar, APIConfigResponse, APIGenesisResponse, APIGetBlobSidecarsResponse,
-    BeaconClient, OnlineBeaconClient,
-};
+pub use beacon_client::{APIConfigResponse, APIGenesisResponse, BeaconClient, OnlineBeaconClient};
 
 pub mod blob_provider;
 pub use blob_provider::{

--- a/crates/providers-alloy/src/test_utils.rs
+++ b/crates/providers-alloy/src/test_utils.rs
@@ -1,9 +1,10 @@
 //! Test Utilities for Online Providers
 
-use crate::{APIBlobSidecar, APIConfigResponse, APIGenesisResponse, APIGetBlobSidecarsResponse};
+use crate::{APIConfigResponse, APIGenesisResponse};
 use alloy_node_bindings::{Anvil, AnvilInstance};
 use alloy_provider::{network::Ethereum, ReqwestProvider};
 use alloy_rpc_client::RpcClient;
+use alloy_rpc_types_beacon::sidecar::{BeaconBlobBundle, BlobData};
 use alloy_transport_http::Http;
 use async_trait::async_trait;
 use kona_derive::sources::IndexedBlobHash;
@@ -37,7 +38,7 @@ pub struct MockBeaconClient {
     /// The beacon genesis.
     pub beacon_genesis: Option<APIGenesisResponse>,
     /// The blob sidecars.
-    pub blob_sidecars: Option<APIGetBlobSidecarsResponse>,
+    pub blob_sidecars: Option<BeaconBlobBundle>,
 }
 
 /// A mock beacon client error
@@ -70,7 +71,7 @@ impl crate::BeaconClient for MockBeaconClient {
         &self,
         _: u64,
         _: &[IndexedBlobHash],
-    ) -> Result<Vec<APIBlobSidecar>, Self::Error> {
+    ) -> Result<Vec<BlobData>, Self::Error> {
         self.blob_sidecars
             .clone()
             .ok_or_else(|| MockBeaconClientError::BlobSidecarsNotSet)


### PR DESCRIPTION
### Description

Re-uses the beacon types from `alloy-rpc-types-beacon` instead of custom api response types.