### PR TITLE
feat(executor): EIP-1559 configurability spec updates

### DIFF
--- a/bin/client/src/fault/handler/bn128_pair.rs
+++ b/bin/client/src/fault/handler/bn128_pair.rs
@@ -20,6 +20,9 @@ const PAIR_ELEMENT_LEN: usize = 64 + 128;
 pub(crate) const FPVM_ECPAIRING: PrecompileWithAddress =
     PrecompileWithAddress(ECPAIRING_ADDRESS, Precompile::Standard(fpvm_ecpairing));
 
+pub(crate) const FPVM_ECPAIRING_GRANITE: PrecompileWithAddress =
+    PrecompileWithAddress(ECPAIRING_ADDRESS, Precompile::Standard(fpvm_ecpairing_granite));
+
 /// Performs an FPVM-accelerated `ecpairing` precompile call.
 fn fpvm_ecpairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     let gas_used =
@@ -58,4 +61,14 @@ fn fpvm_ecpairing(input: &Bytes, gas_limit: u64) -> PrecompileResult {
     .map_err(|e| PrecompileError::Other(e.to_string()))?;
 
     Ok(PrecompileOutput::new(gas_used, result_data.into()))
+}
+
+/// Performs an FPVM-accelerated `ecpairing` precompile call after the Granite hardfork.
+fn fpvm_ecpairing_granite(input: &Bytes, gas_limit: u64) -> PrecompileResult {
+    const BN256_MAX_PAIRING_SIZE_GRANITE: usize = 112_687;
+    if input.len() > BN256_MAX_PAIRING_SIZE_GRANITE {
+        return Err(PrecompileError::Bn128PairLength.into());
+    }
+
+    fpvm_ecpairing(input, gas_limit)
 }

--- a/bin/client/src/fault/handler/mod.rs
+++ b/bin/client/src/fault/handler/mod.rs
@@ -37,6 +37,11 @@ pub(crate) fn fpvm_handle_register<F, H>(
             kzg_point_eval::FPVM_KZG_POINT_EVAL,
         ];
         ctx_precompiles.extend(override_precompiles);
+
+        if spec_id.is_enabled_in(SpecId::GRANITE) {
+            ctx_precompiles.extend([bn128_pair::FPVM_ECPAIRING_GRANITE]);
+        }
+
         ctx_precompiles
     });
 }

--- a/crates/executor/src/errors.rs
+++ b/crates/executor/src/errors.rs
@@ -12,12 +12,18 @@ pub enum ExecutorError {
     /// Missing gas limit in the payload attributes.
     #[error("Gas limit not provided in payload attributes")]
     MissingGasLimit,
+    /// Missing transactions in the payload attributes.
+    #[error("Transactions not provided in payload attributes")]
+    MissingTransactions,
     /// Missing EIP-1559 parameters in execution payload post-Holocene.
     #[error("Missing EIP-1559 parameters in execution payload post-Holocene")]
     MissingEIP1559Params,
     /// Missing parent beacon block root in the payload attributes.
     #[error("Parent beacon block root not provided in payload attributes")]
     MissingParentBeaconBlockRoot,
+    /// Invalid `extraData` field in the block header.
+    #[error("Invalid `extraData` field in the block header")]
+    InvalidExtraData,
     /// Block gas limit exceeded.
     #[error("Block gas limit exceeded")]
     BlockGasLimitExceeded,

--- a/crates/executor/src/util.rs
+++ b/crates/executor/src/util.rs
@@ -1,11 +1,18 @@
 //! Contains utilities for the L2 executor.
 
+use crate::{ExecutorError, ExecutorResult};
 use alloc::vec::Vec;
-use alloy_consensus::{Eip658Value, Receipt, ReceiptWithBloom};
-use alloy_primitives::{Bloom, Log};
+use alloy_consensus::{Eip658Value, Header, Receipt, ReceiptWithBloom};
+use alloy_eips::eip1559::BaseFeeParams;
+use alloy_primitives::{Bloom, Bytes, Log, B64};
 use op_alloy_consensus::{
     OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope, OpTxType,
 };
+use op_alloy_genesis::RollupConfig;
+use op_alloy_rpc_types_engine::OpPayloadAttributes;
+
+/// The version byte for the Holocene extra data.
+const HOLOCENE_EXTRA_DATA_VERSION: u8 = 0x00;
 
 /// Constructs a [OpReceiptEnvelope] from a [Receipt] fields and [OpTxType].
 pub(crate) fn receipt_envelope_from_parts<'a>(
@@ -54,4 +61,197 @@ pub(crate) fn logs_bloom<'a>(logs: impl IntoIterator<Item = &'a Log>) -> Bloom {
         }
     }
     bloom
+}
+
+/// Parse Holocene [Header] extra data.
+///
+/// ## Takes
+/// - `extra_data`: The extra data field of the [Header].
+///
+/// ## Returns
+/// - `Ok(BaseFeeParams)`: The EIP-1559 parameters.
+/// - `Err(ExecutorError::InvalidExtraData)`: If the extra data is invalid.
+pub(crate) fn decode_holocene_eip_1559_params(header: &Header) -> ExecutorResult<BaseFeeParams> {
+    // Check the extra data length.
+    if header.extra_data.len() != 1 + 8 {
+        return Err(ExecutorError::InvalidExtraData);
+    }
+
+    // Check the extra data version byte.
+    if header.extra_data[0] != HOLOCENE_EXTRA_DATA_VERSION {
+        return Err(ExecutorError::InvalidExtraData);
+    }
+
+    // Parse the EIP-1559 parameters.
+    let data = &header.extra_data[1..];
+    let denominator =
+        u32::from_be_bytes(data[..4].try_into().map_err(|_| ExecutorError::InvalidExtraData)?)
+            as u128;
+    let elasticity =
+        u32::from_be_bytes(data[4..].try_into().map_err(|_| ExecutorError::InvalidExtraData)?)
+            as u128;
+
+    // Check for potential division by zero.
+    if denominator == 0 {
+        return Err(ExecutorError::InvalidExtraData);
+    }
+
+    Ok(BaseFeeParams { elasticity_multiplier: elasticity, max_change_denominator: denominator })
+}
+
+/// Encode Holocene [Header] extra data.
+///
+/// ## Takes
+/// - `config`: The [RollupConfig] for the chain.
+/// - `attributes`: The [OpPayloadAttributes] for the block.
+///
+/// ## Returns
+/// - `Ok(data)`: The encoded extra data.
+/// - `Err(ExecutorError::MissingEIP1559Params)`: If the EIP-1559 parameters are missing.
+pub(crate) fn encode_holocene_eip_1559_params(
+    config: &RollupConfig,
+    attributes: &OpPayloadAttributes,
+) -> ExecutorResult<Bytes> {
+    let payload_params = attributes.eip_1559_params.ok_or(ExecutorError::MissingEIP1559Params)?;
+    let params = if payload_params == B64::ZERO {
+        encode_canyon_base_fee_params(config)
+    } else {
+        payload_params
+    };
+
+    let mut data = Vec::with_capacity(1 + 8);
+    data.push(HOLOCENE_EXTRA_DATA_VERSION);
+    data.extend_from_slice(params.as_ref());
+    Ok(data.into())
+}
+
+/// Encodes the canyon base fee parameters, per Holocene spec.
+///
+/// <https://specs.optimism.io/protocol/holocene/exec-engine.html#eip1559params-encoding>
+pub(crate) fn encode_canyon_base_fee_params(config: &RollupConfig) -> B64 {
+    let params = config.canyon_base_fee_params;
+
+    let mut buf = B64::ZERO;
+    buf[..4].copy_from_slice(&(params.max_change_denominator as u32).to_be_bytes());
+    buf[4..].copy_from_slice(&(params.elasticity_multiplier as u32).to_be_bytes());
+    buf
+}
+
+#[cfg(test)]
+mod test {
+    use super::decode_holocene_eip_1559_params;
+    use crate::util::{encode_canyon_base_fee_params, encode_holocene_eip_1559_params};
+    use alloy_consensus::Header;
+    use alloy_eips::eip1559::BaseFeeParams;
+    use alloy_primitives::{b64, hex, B64};
+    use alloy_rpc_types_engine::PayloadAttributes;
+    use op_alloy_genesis::RollupConfig;
+    use op_alloy_rpc_types_engine::OpPayloadAttributes;
+
+    fn mock_payload(eip_1559_params: Option<B64>) -> OpPayloadAttributes {
+        OpPayloadAttributes {
+            payload_attributes: PayloadAttributes {
+                timestamp: 0,
+                prev_randao: Default::default(),
+                suggested_fee_recipient: Default::default(),
+                withdrawals: Default::default(),
+                parent_beacon_block_root: Default::default(),
+            },
+            transactions: None,
+            no_tx_pool: None,
+            gas_limit: None,
+            eip_1559_params,
+        }
+    }
+
+    #[test]
+    fn test_decode_holocene_eip_1559_params() {
+        let params = hex!("00BEEFBABE0BADC0DE");
+        let mock_header = Header { extra_data: params.to_vec().into(), ..Default::default() };
+        let params = decode_holocene_eip_1559_params(&mock_header).unwrap();
+
+        assert_eq!(params.elasticity_multiplier, 0xBADC_0DE);
+        assert_eq!(params.max_change_denominator, 0xBEEF_BABE);
+    }
+
+    #[test]
+    fn test_decode_holocene_eip_1559_params_invalid_version() {
+        let params = hex!("01BEEFBABE0BADC0DE");
+        let mock_header = Header { extra_data: params.to_vec().into(), ..Default::default() };
+        assert!(decode_holocene_eip_1559_params(&mock_header).is_err());
+    }
+
+    #[test]
+    fn test_decode_holocene_eip_1559_params_invalid_denominator() {
+        let params = hex!("00000000000BADC0DE");
+        let mock_header = Header { extra_data: params.to_vec().into(), ..Default::default() };
+        assert!(decode_holocene_eip_1559_params(&mock_header).is_err());
+    }
+
+    #[test]
+    fn test_decode_holocene_eip_1559_params_invalid_length() {
+        let params = hex!("00");
+        let mock_header = Header { extra_data: params.to_vec().into(), ..Default::default() };
+        assert!(decode_holocene_eip_1559_params(&mock_header).is_err());
+    }
+
+    #[test]
+    fn test_encode_holocene_eip_1559_params_missing() {
+        let cfg = RollupConfig {
+            canyon_base_fee_params: BaseFeeParams {
+                max_change_denominator: 32,
+                elasticity_multiplier: 64,
+            },
+            ..Default::default()
+        };
+        let attrs = mock_payload(None);
+
+        assert!(encode_holocene_eip_1559_params(&cfg, &attrs).is_err());
+    }
+
+    #[test]
+    fn test_encode_holocene_eip_1559_params_default() {
+        let cfg = RollupConfig {
+            canyon_base_fee_params: BaseFeeParams {
+                max_change_denominator: 32,
+                elasticity_multiplier: 64,
+            },
+            ..Default::default()
+        };
+        let attrs = mock_payload(Some(B64::ZERO));
+
+        assert_eq!(
+            encode_holocene_eip_1559_params(&cfg, &attrs).unwrap(),
+            hex!("000000002000000040").to_vec()
+        );
+    }
+
+    #[test]
+    fn test_encode_holocene_eip_1559_params() {
+        let cfg = RollupConfig {
+            canyon_base_fee_params: BaseFeeParams {
+                max_change_denominator: 32,
+                elasticity_multiplier: 64,
+            },
+            ..Default::default()
+        };
+        let attrs = mock_payload(Some(b64!("0000004000000060")));
+
+        assert_eq!(
+            encode_holocene_eip_1559_params(&cfg, &attrs).unwrap(),
+            hex!("000000004000000060").to_vec()
+        );
+    }
+
+    #[test]
+    fn test_encode_canyon_1559_params() {
+        let cfg = RollupConfig {
+            canyon_base_fee_params: BaseFeeParams {
+                max_change_denominator: 32,
+                elasticity_multiplier: 64,
+            },
+            ..Default::default()
+        };
+        assert_eq!(encode_canyon_base_fee_params(&cfg), b64!("0000002000000040"));
+    }
 }

--- a/crates/executor/src/util.rs
+++ b/crates/executor/src/util.rs
@@ -170,7 +170,7 @@ mod test {
         let mock_header = Header { extra_data: params.to_vec().into(), ..Default::default() };
         let params = decode_holocene_eip_1559_params(&mock_header).unwrap();
 
-        assert_eq!(params.elasticity_multiplier, 0xBADC_0DE);
+        assert_eq!(params.elasticity_multiplier, 0x0BAD_C0DE);
         assert_eq!(params.max_change_denominator, 0xBEEF_BABE);
     }
 


### PR DESCRIPTION
## Overview

Updates `kona-executor` to be in-line with the new spec, using `extraData` rather than `nonce` to store the EIP-1559 parameters post-holocene.

ref spec: [here](https://specs.optimism.io/protocol/holocene/exec-engine.html#dynamic-eip-1559-parameters)

closes #697 