### PR TITLE
chore: Dependency Updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.39"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "742b81ecb16cc5e9c029d55257cc8d9d5f9409f6384b65d996e583ad62a8c831"
+checksum = "d4932d790c723181807738cf1ac68198ab581cd699545b155601332541ee47bd"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -973,9 +973,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.30"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,17 +68,17 @@ kona-providers-alloy = { path = "crates/providers-alloy", version = "0.0.1", def
 # Alloy
 alloy-rlp = { version = "0.3.8", default-features = false }
 alloy-trie = { version = "0.7.2", default-features = false }
-alloy-eips = { version = "0.5.0", default-features = false }
-alloy-serde = { version = "0.5.0", default-features = false }
-alloy-provider = { version = "0.5.0", default-features = false }
+alloy-eips = { version = "0.5.2", default-features = false }
+alloy-serde = { version = "0.5.2", default-features = false }
+alloy-provider = { version = "0.5.2", default-features = false }
 alloy-primitives = { version = "0.8", default-features = false }
-alloy-consensus = { version = "0.5.0", default-features = false }
-alloy-transport = { version = "0.5.0", default-features = false }
-alloy-rpc-types = { version = "0.5.0", default-features = false }
-alloy-rpc-client = { version = "0.5.0", default-features = false }
-alloy-node-bindings = { version = "0.5.0", default-features = false }
-alloy-transport-http = { version = "0.5.0", default-features = false }
-alloy-rpc-types-engine = { version = "0.5.0", default-features = false }
+alloy-consensus = { version = "0.5.2", default-features = false }
+alloy-transport = { version = "0.5.2", default-features = false }
+alloy-rpc-types = { version = "0.5.2", default-features = false }
+alloy-rpc-client = { version = "0.5.2", default-features = false }
+alloy-node-bindings = { version = "0.5.2", default-features = false }
+alloy-transport-http = { version = "0.5.2", default-features = false }
+alloy-rpc-types-engine = { version = "0.5.2", default-features = false }
 
 # OP Alloy
 op-alloy-genesis = { version = "0.5.0", default-features = false }


### PR DESCRIPTION
### Description

Bumps the recently updated alloy release to the `0.5.2` patch.