### PR TITLE
feat(derive): Hoist Attributes Queue Provider Trait

### DIFF
--- a/crates/derive/src/stages/attributes_queue.rs
+++ b/crates/derive/src/stages/attributes_queue.rs
@@ -4,7 +4,8 @@ use crate::{
     batch::SingleBatch,
     errors::{PipelineError, PipelineResult, ResetError},
     traits::{
-        AttributesBuilder, NextAttributes, OriginAdvancer, OriginProvider, Signal, SignalReceiver,
+        AttributesBuilder, AttributesProvider, NextAttributes, OriginAdvancer, OriginProvider,
+        Signal, SignalReceiver,
     },
 };
 use alloc::{boxed::Box, sync::Arc};
@@ -14,18 +15,6 @@ use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::{BlockInfo, L2BlockInfo};
 use op_alloy_rpc_types_engine::{OpAttributesWithParent, OpPayloadAttributes};
 use tracing::info;
-
-/// [AttributesProvider] is a trait abstraction that generalizes the [BatchQueue] stage.
-///
-/// [BatchQueue]: crate::stages::BatchQueue
-#[async_trait]
-pub trait AttributesProvider {
-    /// Returns the next valid batch upon the given safe head.
-    async fn next_batch(&mut self, parent: L2BlockInfo) -> PipelineResult<SingleBatch>;
-
-    /// Returns whether the current batch is the last in its span.
-    fn is_last_in_span(&self) -> bool;
-}
 
 /// [AttributesQueue] accepts batches from the [BatchQueue] stage
 /// and transforms them into [OpPayloadAttributes].

--- a/crates/derive/src/stages/batch/batch_queue.rs
+++ b/crates/derive/src/stages/batch/batch_queue.rs
@@ -4,9 +4,9 @@ use super::NextBatchProvider;
 use crate::{
     batch::{Batch, BatchValidity, BatchWithInclusionBlock, SingleBatch},
     errors::{PipelineEncodingError, PipelineError, PipelineErrorKind, PipelineResult, ResetError},
-    stages::attributes_queue::AttributesProvider,
     traits::{
-        L2ChainProvider, OriginAdvancer, OriginProvider, ResetSignal, Signal, SignalReceiver,
+        AttributesProvider, L2ChainProvider, OriginAdvancer, OriginProvider, ResetSignal, Signal,
+        SignalReceiver,
     },
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};

--- a/crates/derive/src/stages/batch/batch_validator.rs
+++ b/crates/derive/src/stages/batch/batch_validator.rs
@@ -6,8 +6,7 @@ use crate::{
     errors::ResetError,
     pipeline::{OriginAdvancer, PipelineResult, Signal, SignalReceiver},
     prelude::{OriginProvider, PipelineError, PipelineErrorKind},
-    stages::AttributesProvider,
-    traits::ResetSignal,
+    traits::{AttributesProvider, ResetSignal},
 };
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use async_trait::async_trait;
@@ -318,9 +317,9 @@ mod test {
         errors::{PipelineErrorKind, ResetError},
         pipeline::{PipelineResult, SignalReceiver},
         prelude::PipelineError,
-        stages::{AttributesProvider, NextBatchProvider},
+        stages::NextBatchProvider,
         test_utils::{CollectingLayer, TestBatchQueueProvider, TraceStorage},
-        traits::{OriginAdvancer, ResetSignal, Signal},
+        traits::{AttributesProvider, OriginAdvancer, ResetSignal, Signal},
     };
     use alloc::sync::Arc;
     use alloy_eips::{BlockNumHash, NumHash};

--- a/crates/derive/src/stages/mod.rs
+++ b/crates/derive/src/stages/mod.rs
@@ -34,7 +34,7 @@ mod batch;
 pub use batch::{BatchQueue, BatchStream, BatchStreamProvider, BatchValidator, NextBatchProvider};
 
 mod attributes_queue;
-pub use attributes_queue::{AttributesProvider, AttributesQueue};
+pub use attributes_queue::AttributesQueue;
 
 #[macro_use]
 mod multiplexed;

--- a/crates/derive/src/test_utils/attributes_queue.rs
+++ b/crates/derive/src/test_utils/attributes_queue.rs
@@ -3,8 +3,10 @@
 use crate::{
     batch::SingleBatch,
     errors::{BuilderError, PipelineError, PipelineErrorKind, PipelineResult},
-    stages::AttributesProvider,
-    traits::{AttributesBuilder, OriginAdvancer, OriginProvider, Signal, SignalReceiver},
+    traits::{
+        AttributesBuilder, AttributesProvider, OriginAdvancer, OriginProvider, Signal,
+        SignalReceiver,
+    },
 };
 use alloc::{boxed::Box, string::ToString, vec::Vec};
 use alloy_eips::BlockNumHash;

--- a/crates/derive/src/traits/attributes.rs
+++ b/crates/derive/src/traits/attributes.rs
@@ -1,11 +1,23 @@
 //! Contains traits for working with payload attributes and their providers.
 
-use crate::errors::PipelineResult;
+use crate::{batch::SingleBatch, errors::PipelineResult};
 use alloc::boxed::Box;
 use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use op_alloy_protocol::L2BlockInfo;
 use op_alloy_rpc_types_engine::{OpAttributesWithParent, OpPayloadAttributes};
+
+/// [AttributesProvider] is a trait abstraction that generalizes the [BatchQueue] stage.
+///
+/// [BatchQueue]: crate::stages::BatchQueue
+#[async_trait]
+pub trait AttributesProvider {
+    /// Returns the next valid batch upon the given safe head.
+    async fn next_batch(&mut self, parent: L2BlockInfo) -> PipelineResult<SingleBatch>;
+
+    /// Returns whether the current batch is the last in its span.
+    fn is_last_in_span(&self) -> bool;
+}
 
 /// [NextAttributes] defines the interface for pulling attributes from
 /// the top level `AttributesQueue` stage of the pipeline.

--- a/crates/derive/src/traits/mod.rs
+++ b/crates/derive/src/traits/mod.rs
@@ -8,7 +8,7 @@ mod providers;
 pub use providers::{ChainProvider, L2ChainProvider};
 
 mod attributes;
-pub use attributes::{AttributesBuilder, NextAttributes};
+pub use attributes::{AttributesBuilder, AttributesProvider, NextAttributes};
 
 mod data_sources;
 pub use data_sources::{AsyncIterator, BlobProvider, DataAvailabilityProvider};


### PR DESCRIPTION
### Description

Hoists `AttributesQueue` traits.

Hoisting stage providers to the traits module tidies up the dependency list across stages and makes the separation clearer.

Replaces #599 