### PR TITLE
chore(workspace): Update `asterisc` version to `1.0.3-alpha1`

### DIFF
--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Build `asterisc`
         if: "!contains(matrix.target, 'native')"
         run: |
-          cd asterisc && git checkout v1.0.3.alpha1 && make build-rvgo
+          cd asterisc && git checkout v1.0.3-alpha1 && make build-rvgo
           mv ./rvgo/bin/asterisc /usr/local/bin/
       - name: Set run environment
         run: |

--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Build `asterisc`
         if: "!contains(matrix.target, 'native')"
         run: |
-          cd asterisc && git checkout v1.0.0 && make build-rvgo
+          cd asterisc && git checkout v1.0.3.alpha1 && make build-rvgo
           mv ./rvgo/bin/asterisc /usr/local/bin/
       - name: Set run environment
         run: |

--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -15,7 +15,7 @@ run-client-asterisc block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc ver
 
   HOST_BIN_PATH="./target/release/kona-host"
   CLIENT_BIN_PATH="./target/riscv64gc-unknown-none-elf/release-client-lto/kona"
-  STATE_PATH="./state.json"
+  STATE_PATH="./state.bin.gz"
 
   CLAIMED_L2_BLOCK_NUMBER={{block_number}}
   echo "Fetching configuration for block #$CLAIMED_L2_BLOCK_NUMBER..."
@@ -142,7 +142,7 @@ run-client-asterisc-offline block_number l2_claim l2_output_root l2_head l1_head
 
   HOST_BIN_PATH="./target/release/kona-host"
   CLIENT_BIN_PATH="./target/riscv64gc-unknown-none-elf/release-client-lto/kona"
-  STATE_PATH="./state.json"
+  STATE_PATH="./state.bin.gz"
 
   CLAIMED_L2_BLOCK_NUMBER={{block_number}}
   CLAIMED_L2_OUTPUT_ROOT={{l2_claim}}

--- a/build/asterisc/asterisc-repro.dockerfile
+++ b/build/asterisc/asterisc-repro.dockerfile
@@ -86,7 +86,7 @@ RUN git checkout $CLIENT_TAG && \
   mv ./target/release/kona-host /kona-host
 
 ################################################################
-#        Create `prestate.json` + `prestate-proof.json`        #
+#      Create `prestate.bin.gz` + `prestate-proof.json`        #
 ################################################################
 
 FROM ubuntu:22.04 AS prestate-build
@@ -95,7 +95,7 @@ SHELL ["/bin/bash", "-c"]
 # Set env
 ENV ASTERISC_BIN_PATH="/asterisc"
 ENV CLIENT_BIN_PATH="/kona-client-elf"
-ENV PRESTATE_OUT_PATH="/prestate.json"
+ENV PRESTATE_OUT_PATH="/prestate.bin.gz"
 ENV PROOF_OUT_PATH="/prestate-proof.json"
 
 # Copy asterisc binary
@@ -104,7 +104,7 @@ COPY --from=asterisc-build /asterisc-bin $ASTERISC_BIN_PATH
 # Copy kona-client binary
 COPY --from=client-build /kona-client-elf $CLIENT_BIN_PATH
 
-# Create `prestate.json`
+# Create `prestate.bin.gz`
 RUN $ASTERISC_BIN_PATH load-elf \
   --path=$CLIENT_BIN_PATH \
   --out=$PRESTATE_OUT_PATH
@@ -127,6 +127,6 @@ FROM ubuntu:22.04 AS export-stage
 
 COPY --from=prestate-build /asterisc .
 COPY --from=prestate-build /kona-client-elf .
-COPY --from=prestate-build /prestate.json .
+COPY --from=prestate-build /prestate.bin.gz .
 COPY --from=prestate-build /prestate-proof.json .
 COPY --from=host-build /kona-host .


### PR DESCRIPTION
## Overview

Updates the workspace's version of `asterisc` to `v1.0.3-alpha1`. This release contains the radix trie memory changes, which we need to start testing against.