### PR TITLE
feat(ci): Bump `go` version for action tests

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go toolchain
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21.6"
+          go-version: "1.22.7"
           cache-dependency-path: |
             monorepo/go.sum
       - name: Install Foundry


### PR DESCRIPTION
## Overview

Updates the Go version for the action tests job.