### PR TITLE
feat: Remove thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4932d790c723181807738cf1ac68198ab581cd699545b155601332541ee47bd"
+checksum = "60888eb8eb66f26aecf96d8a3aeb1a3a05ebc179025a7f98ed1d8051988969ac"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -153,7 +153,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror 1.0.65",
+ "thiserror",
  "tracing",
 ]
 
@@ -175,7 +175,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
- "thiserror 1.0.65",
+ "thiserror",
 ]
 
 [[package]]
@@ -203,7 +203,7 @@ dependencies = [
  "rand",
  "serde_json",
  "tempfile",
- "thiserror 1.0.65",
+ "thiserror",
  "tracing",
  "url",
 ]
@@ -269,7 +269,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "thiserror 1.0.65",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -344,7 +344,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "serde",
  "serde_with",
- "thiserror 1.0.65",
+ "thiserror",
 ]
 
 [[package]]
@@ -404,7 +404,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror 1.0.65",
+ "thiserror",
 ]
 
 [[package]]
@@ -477,7 +477,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 1.0.65",
+ "thiserror",
  "tokio",
  "tower",
  "tracing",
@@ -538,9 +538,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -553,36 +553,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1132,9 +1132,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "command-fds"
@@ -1143,7 +1143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb11bd1378bf3731b182997b40cefe00aba6a6cc74042c8318c1b271d3badf7"
 dependencies = [
  "nix 0.27.1",
- "thiserror 1.0.65",
+ "thiserror",
  "tokio",
 ]
 
@@ -2216,8 +2216,8 @@ name = "kona-common"
 version = "0.0.3"
 dependencies = [
  "cfg-if",
+ "derive_more",
  "linked_list_allocator",
- "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -2248,6 +2248,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "brotli",
+ "derive_more",
  "lazy_static",
  "miniz_oxide",
  "op-alloy-consensus",
@@ -2259,7 +2260,6 @@ dependencies = [
  "serde",
  "serde_json",
  "spin",
- "thiserror 1.0.64",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2282,6 +2282,7 @@ dependencies = [
  "alloy-transport",
  "alloy-transport-http",
  "async-trait",
+ "derive_more",
  "kona-derive",
  "lazy_static",
  "lru",
@@ -2292,7 +2293,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 1.0.64",
  "tokio",
  "tracing",
 ]
@@ -2308,6 +2308,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "anyhow",
  "criterion",
+ "derive_more",
  "kona-mpt",
  "op-alloy-consensus",
  "op-alloy-genesis",
@@ -2317,7 +2318,6 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 1.0.64",
  "tracing",
 ]
 
@@ -2376,7 +2376,6 @@ dependencies = [
  "proptest",
  "rand",
  "reqwest",
- "thiserror 1.0.64",
  "tokio",
  "tracing-subscriber",
 ]
@@ -2387,11 +2386,11 @@ version = "0.0.3"
 dependencies = [
  "alloy-primitives",
  "async-trait",
+ "derive_more",
  "kona-common",
  "os_pipe",
  "rkyv",
  "serde",
- "thiserror 1.0.64",
  "tokio",
  "tracing",
 ]
@@ -2977,7 +2976,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror 1.0.65",
+ "thiserror",
  "ucd-trie",
 ]
 
@@ -3082,7 +3081,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror 1.0.65",
+ "thiserror",
 ]
 
 [[package]]
@@ -3191,7 +3190,7 @@ dependencies = [
  "parking_lot",
  "procfs",
  "protobuf",
- "thiserror 1.0.65",
+ "thiserror",
 ]
 
 [[package]]
@@ -4251,29 +4250,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
-source = "git+https://github.com/quartiq/thiserror?branch=no-std#e779e1b70023cee5807f378e147f66387d1ccd4f"
-dependencies = [
- "thiserror-impl 1.0.64",
-]
-
-[[package]]
-name = "thiserror"
 version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
- "thiserror-impl 1.0.65",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.64"
-source = "git+https://github.com/quartiq/thiserror?branch=no-std#e779e1b70023cee5807f378e147f66387d1ccd4f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.85",
+ "thiserror-impl",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,9 +86,6 @@ op-alloy-protocol = { version = "0.5.1", default-features = false }
 op-alloy-consensus = { version = "0.5.1", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.5.1", default-features = false }
 
-# `no_std` support
-thiserror = { git = "https://github.com/quartiq/thiserror", branch = "no-std", default-features = false }
-
 # General
 lru = "0.12.4"
 spin = "0.9.8"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -13,5 +13,5 @@ workspace = true
 
 [dependencies]
 cfg-if.workspace = true
-thiserror.workspace = true
+derive_more = { workspace = true, features = ["full"] }
 linked_list_allocator.workspace = true

--- a/crates/common/src/errors.rs
+++ b/crates/common/src/errors.rs
@@ -1,11 +1,11 @@
 //! Errors for the `kona-common` crate.
 
-use thiserror::Error;
-
 /// An error that can occur when reading from or writing to a file descriptor.
-#[derive(Error, Debug, PartialEq, Eq)]
-#[error("IO error (errno: {0})")]
+#[derive(derive_more::Display, Debug, PartialEq, Eq)]
+#[display("IO error (errno: {_0})")]
 pub struct IOError(pub i32);
+
+impl core::error::Error for IOError {}
 
 /// A [Result] type for the [IOError].
 pub type IOResult<T> = Result<T, IOError>;

--- a/crates/derive-alloy/Cargo.toml
+++ b/crates/derive-alloy/Cargo.toml
@@ -42,13 +42,13 @@ lazy_static = { workspace = true, optional = true }
 prometheus = { workspace = true, optional = true, features = ["process"] }
 
 # `test-utils` feature dependencies
-thiserror = { workspace = true, optional = true }
+derive_more = { workspace = true, features = ["full"], optional = true }
 alloy-rpc-client = { workspace = true, optional = true }
 alloy-node-bindings = { workspace = true, optional = true }
 alloy-transport-http = { workspace = true, optional = true, features = ["reqwest"] }
 
 [dev-dependencies]
-thiserror.workspace = true
+derive_more = { workspace = true, features = ["full"] }
 serde_json.workspace = true
 alloy-rpc-client.workspace = true
 alloy-node-bindings.workspace = true
@@ -60,7 +60,7 @@ kona-derive = { workspace = true, features = ["serde", "test-utils"] }
 default = []
 metrics = ["dep:prometheus", "dep:lazy_static"]
 test-utils = [
-  "dep:thiserror",
+  "dep:derive_more",
   "dep:alloy-rpc-client",
   "dep:alloy-node-bindings",
   "dep:alloy-transport-http",

--- a/crates/derive-alloy/src/test_utils.rs
+++ b/crates/derive-alloy/src/test_utils.rs
@@ -42,18 +42,20 @@ pub struct MockBeaconClient {
 }
 
 /// A mock beacon client error
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, derive_more::Display)]
 pub enum MockBeaconClientError {
     /// The config spec is not set
-    #[error("config_spec not set")]
+    #[display("config_spec not set")]
     ConfigSpecNotSet,
     /// The beacon genesis is not set
-    #[error("beacon_genesis not set")]
+    #[display("beacon_genesis not set")]
     BeaconGenesisNotSet,
     /// The blob sidecars are not set
-    #[error("blob_sidecars not set")]
+    #[display("blob_sidecars not set")]
     BlobSidecarsNotSet,
 }
+
+impl core::error::Error for MockBeaconClientError {}
 
 #[async_trait]
 impl crate::BeaconClient for MockBeaconClient {

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -28,11 +28,11 @@ op-alloy-consensus = { workspace = true, features = ["k256"] }
 # General
 brotli.workspace = true
 tracing.workspace = true
-thiserror.workspace = true
 miniz_oxide.workspace = true
 async-trait.workspace = true
 unsigned-varint.workspace = true
 alloc-no-stdlib.workspace = true
+derive_more = { workspace = true, features = ["full"] }
 
 # `serde` feature dependencies
 serde = { workspace = true, optional = true, features = ["derive"] }

--- a/crates/derive/src/batch/span_batch/errors.rs
+++ b/crates/derive/src/batch/span_batch/errors.rs
@@ -1,62 +1,77 @@
 //! Span Batch Errors
 
-use thiserror::Error;
-
 /// Span Batch Errors
-#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[derive(derive_more::Display, Debug, Clone, PartialEq, Eq)]
 pub enum SpanBatchError {
     /// The span batch is too big
-    #[error("The span batch is too big.")]
+    #[display("The span batch is too big.")]
     TooBigSpanBatchSize,
     /// The bit field is too long
-    #[error("The bit field is too long")]
+    #[display("The bit field is too long")]
     BitfieldTooLong,
     /// Empty Span Batch
-    #[error("Empty span batch")]
+    #[display("Empty span batch")]
     EmptySpanBatch,
     /// Missing L1 origin
-    #[error("Missing L1 origin")]
+    #[display("Missing L1 origin")]
     MissingL1Origin,
     /// Decoding errors
-    #[error("Span batch decoding error: {0}")]
-    Decoding(#[from] SpanDecodingError),
+    #[display("Span batch decoding error: {_0}")]
+    Decoding(SpanDecodingError),
+}
+
+impl From<SpanDecodingError> for SpanBatchError {
+    fn from(e: SpanDecodingError) -> Self {
+        Self::Decoding(e)
+    }
+}
+
+impl core::error::Error for SpanBatchError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Decoding(e) => Some(e),
+            _ => None,
+        }
+    }
 }
 
 /// Decoding Error
-#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[derive(derive_more::Display, Debug, Clone, PartialEq, Eq)]
 pub enum SpanDecodingError {
     /// Failed to decode relative timestamp
-    #[error("Failed to decode relative timestamp")]
+    #[display("Failed to decode relative timestamp")]
     RelativeTimestamp,
     /// Failed to decode L1 origin number
-    #[error("Failed to decode L1 origin number")]
+    #[display("Failed to decode L1 origin number")]
     L1OriginNumber,
     /// Failed to decode parent check
-    #[error("Failed to decode parent check")]
+    #[display("Failed to decode parent check")]
     ParentCheck,
     /// Failed to decode L1 origin check
-    #[error("Failed to decode L1 origin check")]
+    #[display("Failed to decode L1 origin check")]
     L1OriginCheck,
     /// Failed to decode block count
-    #[error("Failed to decode block count")]
+    #[display("Failed to decode block count")]
     BlockCount,
     /// Failed to decode block tx counts
-    #[error("Failed to decode block tx counts")]
+    #[display("Failed to decode block tx counts")]
     BlockTxCounts,
     /// Failed to decode transaction nonces
-    #[error("Failed to decode transaction nonces")]
+    #[display("Failed to decode transaction nonces")]
     TxNonces,
     /// Mismatch in length between the transaction type and signature arrays in a span batch
     /// transaction payload.
-    #[error("Mismatch in length between the transaction type and signature arrays")]
+    #[display("Mismatch in length between the transaction type and signature arrays")]
     TypeSignatureLenMismatch,
     /// Invalid transaction type
-    #[error("Invalid transaction type")]
+    #[display("Invalid transaction type")]
     InvalidTransactionType,
     /// Invalid transaction data
-    #[error("Invalid transaction data")]
+    #[display("Invalid transaction data")]
     InvalidTransactionData,
     /// Invalid transaction signature
-    #[error("Invalid transaction signature")]
+    #[display("Invalid transaction signature")]
     InvalidTransactionSignature,
 }
+
+impl core::error::Error for SpanDecodingError {}

--- a/crates/derive/src/errors.rs
+++ b/crates/derive/src/errors.rs
@@ -6,24 +6,25 @@ use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
 use op_alloy_genesis::system::SystemConfigUpdateError;
 use op_alloy_protocol::DepositError;
-use thiserror::Error;
 
 /// Blob Decuding Error
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(derive_more::Display, Debug, PartialEq, Eq)]
 pub enum BlobDecodingError {
     /// Invalid field element
-    #[error("Invalid field element")]
+    #[display("Invalid field element")]
     InvalidFieldElement,
     /// Invalid encoding version
-    #[error("Invalid encoding version")]
+    #[display("Invalid encoding version")]
     InvalidEncodingVersion,
     /// Invalid length
-    #[error("Invalid length")]
+    #[display("Invalid length")]
     InvalidLength,
     /// Missing Data
-    #[error("Missing data")]
+    #[display("Missing data")]
     MissingData,
 }
+
+impl core::error::Error for BlobDecodingError {}
 
 /// A result type for the derivation pipeline stages.
 pub type PipelineResult<T> = Result<T, PipelineErrorKind>;
@@ -39,83 +40,121 @@ macro_rules! ensure {
 }
 
 /// A top level filter for [PipelineError] that sorts by severity.
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(derive_more::Display, Debug, PartialEq, Eq)]
 pub enum PipelineErrorKind {
     /// A temporary error.
-    #[error("Temporary error: {0}")]
-    Temporary(#[source] PipelineError),
+    #[display("Temporary error: {_0}")]
+    Temporary(PipelineError),
     /// A critical error.
-    #[error("Critical error: {0}")]
-    Critical(#[source] PipelineError),
+    #[display("Critical error: {_0}")]
+    Critical(PipelineError),
     /// A reset error.
-    #[error("Pipeline reset: {0}")]
-    Reset(#[from] ResetError),
+    #[display("Pipeline reset: {_0}")]
+    Reset(ResetError),
+}
+
+impl From<ResetError> for PipelineErrorKind {
+    fn from(err: ResetError) -> Self {
+        Self::Reset(err)
+    }
+}
+
+impl core::error::Error for PipelineErrorKind {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Temporary(err) => Some(err),
+            Self::Critical(err) => Some(err),
+            Self::Reset(err) => Some(err),
+        }
+    }
 }
 
 /// An error encountered during the processing.
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(derive_more::Display, Debug, PartialEq, Eq)]
 pub enum PipelineError {
     /// There is no data to read from the channel bank.
-    #[error("EOF")]
+    #[display("EOF")]
     Eof,
     /// There is not enough data to complete the processing of the stage. If the operation is
     /// re-tried, more data will come in allowing the pipeline to progress, or eventually a
     /// [PipelineError::Eof] will be encountered.
-    #[error("Not enough data")]
+    #[display("Not enough data")]
     NotEnoughData,
     /// No channels are available in the [ChannelProvider].
     ///
     /// [ChannelProvider]: crate::stages::ChannelProvider
-    #[error("The channel provider is empty")]
+    #[display("The channel provider is empty")]
     ChannelProviderEmpty,
     /// The channel has already been built by the [ChannelAssembler] stage.
     ///
     /// [ChannelAssembler]: crate::stages::ChannelAssembler
-    #[error("Channel already built")]
+    #[display("Channel already built")]
     ChannelAlreadyBuilt,
     /// Failed to find channel in the [ChannelProvider].
     ///
     /// [ChannelProvider]: crate::stages::ChannelProvider
-    #[error("Channel not found in channel provider")]
+    #[display("Channel not found in channel provider")]
     ChannelNotFound,
     /// No channel returned by the [ChannelReader] stage.
     ///
     /// [ChannelReader]: crate::stages::ChannelReader
-    #[error("The channel reader has no channel available")]
+    #[display("The channel reader has no channel available")]
     ChannelReaderEmpty,
     /// The [BatchQueue] is empty.
     ///
     /// [BatchQueue]: crate::stages::BatchQueue
-    #[error("The batch queue has no batches available")]
+    #[display("The batch queue has no batches available")]
     BatchQueueEmpty,
     /// Missing L1 origin.
-    #[error("Missing L1 origin from previous stage")]
+    #[display("Missing L1 origin from previous stage")]
     MissingOrigin,
     /// Missing data from [L1Retrieval].
     ///
     /// [L1Retrieval]: crate::stages::L1Retrieval
-    #[error("L1 Retrieval missing data")]
+    #[display("L1 Retrieval missing data")]
     MissingL1Data,
     /// Invalid batch type passed.
-    #[error("Invalid batch type passed to stage")]
+    #[display("Invalid batch type passed to stage")]
     InvalidBatchType,
     /// Invalid batch validity variant.
-    #[error("Invalid batch validity")]
+    #[display("Invalid batch validity")]
     InvalidBatchValidity,
     /// [SystemConfig] update error.
     ///
     /// [SystemConfig]: op_alloy_genesis::SystemConfig
-    #[error("Error updating system config: {0}")]
+    #[display("Error updating system config: {_0}")]
     SystemConfigUpdate(SystemConfigUpdateError),
     /// Attributes builder error variant, with [BuilderError].
-    #[error("Attributes builder error: {0}")]
-    AttributesBuilder(#[from] BuilderError),
+    #[display("Attributes builder error: {_0}")]
+    AttributesBuilder(BuilderError),
     /// [PipelineEncodingError] variant.
-    #[error("Decode error: {0}")]
-    BadEncoding(#[from] PipelineEncodingError),
+    #[display("Decode error: {_0}")]
+    BadEncoding(PipelineEncodingError),
     /// Provider error variant.
-    #[error("Blob provider error: {0}")]
+    #[display("Blob provider error: {_0}")]
     Provider(String),
+}
+
+impl From<BuilderError> for PipelineError {
+    fn from(err: BuilderError) -> Self {
+        Self::AttributesBuilder(err)
+    }
+}
+
+impl From<PipelineEncodingError> for PipelineError {
+    fn from(err: PipelineEncodingError) -> Self {
+        Self::BadEncoding(err)
+    }
+}
+
+impl core::error::Error for PipelineError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::AttributesBuilder(err) => Some(err),
+            Self::BadEncoding(err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 impl PipelineError {
@@ -131,33 +170,41 @@ impl PipelineError {
 }
 
 /// A reset error
-#[derive(Error, Clone, Debug, Eq, PartialEq)]
+#[derive(derive_more::Display, Clone, Debug, Eq, PartialEq)]
 pub enum ResetError {
     /// The batch has a bad parent hash.
     /// The first argument is the expected parent hash, and the second argument is the actual
     /// parent hash.
-    #[error("Bad parent hash: expected {0}, got {1}")]
+    #[display("Bad parent hash: expected {_0}, got {_1}")]
     BadParentHash(B256, B256),
     /// The batch has a bad timestamp.
     /// The first argument is the expected timestamp, and the second argument is the actual
     /// timestamp.
-    #[error("Bad timestamp: expected {0}, got {1}")]
+    #[display("Bad timestamp: expected {_0}, got {_1}")]
     BadTimestamp(u64, u64),
     /// L1 origin mismatch.
-    #[error("L1 origin mismatch. Expected {0:?}, got {1:?}")]
+    #[display("L1 origin mismatch. Expected {_0:?}, got {_1:?}")]
     L1OriginMismatch(u64, u64),
     /// The stage detected a block reorg.
     /// The first argument is the expected block hash.
     /// The second argument is the parent_hash of the next l1 origin block.
-    #[error("L1 reorg detected: expected {0}, got {1}")]
+    #[display("L1 reorg detected: expected {_0}, got {_1}")]
     ReorgDetected(B256, B256),
     /// Attributes builder error variant, with [BuilderError].
-    #[error("Attributes builder error: {0}")]
-    AttributesBuilder(#[from] BuilderError),
+    #[display("Attributes builder error: {_0}")]
+    AttributesBuilder(BuilderError),
     /// A Holocene activation temporary error.
-    #[error("Holocene activation reset")]
+    #[display("Holocene activation reset")]
     HoloceneActivation,
 }
+
+impl From<BuilderError> for ResetError {
+    fn from(err: BuilderError) -> Self {
+        Self::AttributesBuilder(err)
+    }
+}
+
+impl core::error::Error for ResetError {}
 
 impl ResetError {
     /// Wrap [self] as a [PipelineErrorKind::Reset].
@@ -167,73 +214,107 @@ impl ResetError {
 }
 
 /// A decoding error.
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(derive_more::Display, Debug, PartialEq, Eq)]
 pub enum PipelineEncodingError {
     /// The buffer is empty.
-    #[error("Empty buffer")]
+    #[display("Empty buffer")]
     EmptyBuffer,
     /// Deposit decoding error.
-    #[error("Error decoding deposit: {0}")]
-    DepositError(#[from] DepositError),
+    #[display("Error decoding deposit: {_0}")]
+    DepositError(DepositError),
     /// Alloy RLP Encoding Error.
-    #[error("RLP error: {0}")]
+    #[display("RLP error: {_0}")]
     AlloyRlpError(alloy_rlp::Error),
     /// Span Batch Error.
-    #[error(transparent)]
-    SpanBatchError(#[from] SpanBatchError),
+    #[display("{_0}")]
+    SpanBatchError(SpanBatchError),
+}
+
+impl core::error::Error for PipelineEncodingError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::DepositError(err) => Some(err),
+            Self::SpanBatchError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<SpanBatchError> for PipelineEncodingError {
+    fn from(err: SpanBatchError) -> Self {
+        Self::SpanBatchError(err)
+    }
+}
+
+impl From<DepositError> for PipelineEncodingError {
+    fn from(err: DepositError) -> Self {
+        Self::DepositError(err)
+    }
 }
 
 /// A frame decompression error.
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(derive_more::Display, Debug, PartialEq, Eq)]
 pub enum BatchDecompressionError {
     /// The buffer exceeds the [MAX_SPAN_BATCH_ELEMENTS] protocol parameter.
-    #[error("The batch exceeds the maximum number of elements: {max_size}", max_size = MAX_SPAN_BATCH_ELEMENTS)]
+    #[display("The batch exceeds the maximum number of elements: {max_size}", max_size = MAX_SPAN_BATCH_ELEMENTS)]
     BatchTooLarge,
 }
+
+impl core::error::Error for BatchDecompressionError {}
 
 /// An [AttributesBuilder] Error.
 ///
 /// [AttributesBuilder]: crate::traits::AttributesBuilder
-#[derive(Error, Clone, Debug, PartialEq, Eq)]
+#[derive(derive_more::Display, Clone, Debug, PartialEq, Eq)]
 pub enum BuilderError {
     /// Mismatched blocks.
-    #[error("Block mismatch. Expected {0:?}, got {1:?}")]
+    #[display("Block mismatch. Expected {_0:?}, got {_1:?}")]
     BlockMismatch(BlockNumHash, BlockNumHash),
     /// Mismatched blocks for the start of an Epoch.
-    #[error("Block mismatch on epoch reset. Expected {0:?}, got {1:?}")]
+    #[display("Block mismatch on epoch reset. Expected {_0:?}, got {_1:?}")]
     BlockMismatchEpochReset(BlockNumHash, BlockNumHash, B256),
     /// [SystemConfig] update failed.
     ///
     /// [SystemConfig]: op_alloy_genesis::SystemConfig
-    #[error("System config update failed")]
+    #[display("System config update failed")]
     SystemConfigUpdate,
     /// Broken time invariant between L2 and L1.
-    #[error("Time invariant broken. L1 origin: {0:?} | Next L2 time: {1} | L1 block: {2:?} | L1 timestamp {3:?}")]
+    #[display("Time invariant broken. L1 origin: {_0:?} | Next L2 time: {_1} | L1 block: {_2:?} | L1 timestamp {_3:?}")]
     BrokenTimeInvariant(BlockNumHash, u64, BlockNumHash, u64),
     /// Attributes unavailable.
-    #[error("Attributes unavailable")]
+    #[display("Attributes unavailable")]
     AttributesUnavailable,
     /// A custom error.
-    #[error("Error in attributes builder: {0}")]
+    #[display("Error in attributes builder: {_0}")]
     Custom(String),
 }
 
+impl core::error::Error for BuilderError {}
+
 /// An error returned by the [BlobProviderError].
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(derive_more::Display, Debug, PartialEq, Eq)]
 pub enum BlobProviderError {
     /// The number of specified blob hashes did not match the number of returned sidecars.
-    #[error("Blob sidecar length mismatch: expected {0}, got {1}")]
+    #[display("Blob sidecar length mismatch: expected {_0}, got {_1}")]
     SidecarLengthMismatch(usize, usize),
     /// Slot derivation error.
-    #[error("Failed to derive slot")]
+    #[display("Failed to derive slot")]
     SlotDerivation,
     /// Blob decoding error.
-    #[error("Blob decoding error: {0}")]
-    BlobDecoding(#[from] BlobDecodingError),
+    #[display("Blob decoding error: {_0}")]
+    BlobDecoding(BlobDecodingError),
     /// Error pertaining to the backend transport.
-    #[error("{0}")]
+    #[display("{_0}")]
     Backend(String),
 }
+
+impl From<BlobDecodingError> for BlobProviderError {
+    fn from(err: BlobDecodingError) -> Self {
+        Self::BlobDecoding(err)
+    }
+}
+
+impl core::error::Error for BlobProviderError {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/derive/src/test_utils/chain_providers.rs
+++ b/crates/derive/src/test_utils/chain_providers.rs
@@ -73,24 +73,26 @@ impl TestChainProvider {
 }
 
 /// An error for the [TestChainProvider] and [TestL2ChainProvider].
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, derive_more::Display)]
 pub enum TestProviderError {
     /// The block was not found.
-    #[error("Block not found")]
+    #[display("Block not found")]
     BlockNotFound,
     /// The header was not found.
-    #[error("Header not found")]
+    #[display("Header not found")]
     HeaderNotFound,
     /// The receipts were not found.
-    #[error("Receipts not found")]
+    #[display("Receipts not found")]
     ReceiptsNotFound,
     /// The L2 block was not found.
-    #[error("L2 Block not found")]
+    #[display("L2 Block not found")]
     L2BlockNotFound,
     /// The system config was not found.
-    #[error("System config not found")]
+    #[display("System config not found")]
     SystemConfigNotFound(u64),
 }
+
+impl core::error::Error for TestProviderError {}
 
 #[async_trait]
 impl ChainProvider for TestChainProvider {

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -30,7 +30,7 @@ op-alloy-rpc-types-engine.workspace = true
 revm = { workspace = true, features = ["optimism"] }
 
 # General
-thiserror.workspace = true
+derive_more = { workspace = true, features = ["full"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/executor/src/errors.rs
+++ b/crates/executor/src/errors.rs
@@ -3,46 +3,66 @@
 use alloc::string::String;
 use kona_mpt::TrieNodeError;
 use revm::primitives::EVMError;
-use thiserror::Error;
 
 /// The error type for the [StatelessL2BlockExecutor].
 ///
 /// [StatelessL2BlockExecutor]: crate::StatelessL2BlockExecutor
-#[derive(Error, Debug)]
+#[derive(derive_more::Display, Debug)]
 pub enum ExecutorError {
     /// Missing gas limit in the payload attributes.
-    #[error("Gas limit not provided in payload attributes")]
+    #[display("Gas limit not provided in payload attributes")]
     MissingGasLimit,
     /// Missing transactions in the payload attributes.
-    #[error("Transactions not provided in payload attributes")]
+    #[display("Transactions not provided in payload attributes")]
     MissingTransactions,
     /// Missing EIP-1559 parameters in execution payload post-Holocene.
-    #[error("Missing EIP-1559 parameters in execution payload post-Holocene")]
+    #[display("Missing EIP-1559 parameters in execution payload post-Holocene")]
     MissingEIP1559Params,
     /// Missing parent beacon block root in the payload attributes.
-    #[error("Parent beacon block root not provided in payload attributes")]
+    #[display("Parent beacon block root not provided in payload attributes")]
     MissingParentBeaconBlockRoot,
     /// Invalid `extraData` field in the block header.
-    #[error("Invalid `extraData` field in the block header")]
+    #[display("Invalid `extraData` field in the block header")]
     InvalidExtraData,
     /// Block gas limit exceeded.
-    #[error("Block gas limit exceeded")]
+    #[display("Block gas limit exceeded")]
     BlockGasLimitExceeded,
     /// Unsupported transaction type.
-    #[error("Unsupported transaction type: {0}")]
+    #[display("Unsupported transaction type: {_0}")]
     UnsupportedTransactionType(u8),
     /// Trie DB error.
-    #[error("Trie error: {0}")]
-    TrieDBError(#[from] TrieDBError),
+    #[display("Trie error: {_0}")]
+    TrieDBError(TrieDBError),
     /// Execution error.
-    #[error("Execution error: {0}")]
+    #[display("Execution error: {_0}")]
     ExecutionError(EVMError<TrieDBError>),
     /// Signature error.
-    #[error("Signature error: {0}")]
+    #[display("Signature error: {_0}")]
     SignatureError(alloy_primitives::SignatureError),
     /// RLP error.
-    #[error("RLP error: {0}")]
+    #[display("RLP error: {_0}")]
     RLPError(alloy_eips::eip2718::Eip2718Error),
+}
+
+impl From<TrieDBError> for ExecutorError {
+    fn from(err: TrieDBError) -> Self {
+        Self::TrieDBError(err)
+    }
+}
+
+impl From<TrieNodeError> for ExecutorError {
+    fn from(err: TrieNodeError) -> Self {
+        Self::TrieDBError(TrieDBError::TrieNode(err))
+    }
+}
+
+impl core::error::Error for ExecutorError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::TrieDBError(err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 /// A [Result] type for the [ExecutorError] enum.
@@ -54,18 +74,33 @@ pub type TrieDBResult<T> = Result<T, TrieDBError>;
 /// An error type for [TrieDB] operations.
 ///
 /// [TrieDB]: crate::TrieDB
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(derive_more::Display, Debug, PartialEq, Eq)]
 pub enum TrieDBError {
     /// Trie root node has not been blinded.
-    #[error("Trie root node has not been blinded")]
+    #[display("Trie root node has not been blinded")]
     RootNotBlinded,
     /// Missing account info for bundle account.
-    #[error("Missing account info for bundle account.")]
+    #[display("Missing account info for bundle account.")]
     MissingAccountInfo,
     /// Trie node error.
-    #[error("Trie node error: {0}")]
-    TrieNode(#[from] TrieNodeError),
+    #[display("Trie node error: {_0}")]
+    TrieNode(TrieNodeError),
     /// Trie provider error.
-    #[error("Trie provider error: {0}")]
+    #[display("Trie provider error: {_0}")]
     Provider(String),
+}
+
+impl core::error::Error for TrieDBError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::TrieNode(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<TrieNodeError> for TrieDBError {
+    fn from(err: TrieNodeError) -> Self {
+        Self::TrieNode(err)
+    }
 }

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 # General
-thiserror.workspace = true
 derive_more = { workspace = true, features = ["full"] }
 
 # Revm + Alloy

--- a/crates/mpt/src/errors.rs
+++ b/crates/mpt/src/errors.rs
@@ -1,7 +1,6 @@
 //! Errors for the `kona-derive` crate.
 
 use alloc::string::String;
-use thiserror::Error;
 
 /// A [Result] type alias where the error is [TrieNodeError].
 pub type TrieNodeResult<T> = Result<T, TrieNodeError>;
@@ -9,21 +8,23 @@ pub type TrieNodeResult<T> = Result<T, TrieNodeError>;
 /// An error type for [TrieNode] operations.
 ///
 /// [TrieNode]: crate::TrieNode
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Debug, derive_more::Display, PartialEq, Eq)]
 pub enum TrieNodeError {
     /// Invalid trie node type encountered.
-    #[error("Invalid trie node type encountered")]
+    #[display("Invalid trie node type encountered")]
     InvalidNodeType,
     /// Failed to decode trie node.
-    #[error("Failed to decode trie node: {0}")]
+    #[display("Failed to decode trie node: {_0}")]
     RLPError(alloy_rlp::Error),
     /// Key does not exist in trie.
-    #[error("Key does not exist in trie. Encountered {0} node.")]
+    #[display("Key does not exist in trie. Encountered {_0} node.")]
     KeyNotFound(String),
     /// Trie node is not a leaf node.
-    #[error("Trie provider error: {0}")]
+    #[display("Trie provider error: {_0}")]
     Provider(String),
 }
+
+impl core::error::Error for TrieNodeError {}
 
 /// A [Result] type alias where the error is [OrderedListWalkerError].
 pub type OrderedListWalkerResult<T> = Result<T, OrderedListWalkerError>;
@@ -31,12 +32,29 @@ pub type OrderedListWalkerResult<T> = Result<T, OrderedListWalkerError>;
 /// An error type for [OrderedListWalker] operations.
 ///
 /// [OrderedListWalker]: crate::OrderedListWalker
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(derive_more::Display, Debug, PartialEq, Eq)]
 pub enum OrderedListWalkerError {
     /// Iterator has already been hydrated, and cannot be re-hydrated until it is exhausted.
-    #[error("Iterator has already been hydrated, and cannot be re-hydrated until it is exhausted")]
+    #[display(
+        "Iterator has already been hydrated, and cannot be re-hydrated until it is exhausted"
+    )]
     AlreadyHydrated,
     /// Trie node error.
-    #[error(transparent)]
-    TrieNode(#[from] TrieNodeError),
+    #[display("{_0}")]
+    TrieNode(TrieNodeError),
+}
+
+impl From<TrieNodeError> for OrderedListWalkerError {
+    fn from(err: TrieNodeError) -> Self {
+        Self::TrieNode(err)
+    }
+}
+
+impl core::error::Error for OrderedListWalkerError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::TrieNode(err) => Some(err),
+            _ => None,
+        }
+    }
 }

--- a/crates/preimage/Cargo.toml
+++ b/crates/preimage/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 # General
 tracing.workspace = true
-thiserror.workspace = true
+derive_more = { workspace = true, features = ["full"] }
 async-trait.workspace = true
 alloy-primitives.workspace = true
 

--- a/crates/preimage/src/errors.rs
+++ b/crates/preimage/src/errors.rs
@@ -2,30 +2,50 @@
 
 use alloc::string::String;
 use kona_common::errors::IOError;
-use thiserror::Error;
 
 /// A [PreimageOracleError] is an enum that differentiates pipe-related errors from other errors
 /// in the [PreimageOracleServer] and [HintReaderServer] implementations.
 ///
 /// [PreimageOracleServer]: crate::PreimageOracleServer
 /// [HintReaderServer]: crate::HintReaderServer
-#[derive(Error, Debug)]
+#[derive(derive_more::Display, Debug)]
 pub enum PreimageOracleError {
     /// The pipe has been broken.
-    #[error(transparent)]
-    IOError(#[from] IOError),
+    #[display("{_0}")]
+    IOError(IOError),
     /// The preimage key is invalid.
-    #[error(transparent)]
-    InvalidPreimageKey(#[from] InvalidPreimageKeyType),
+    #[display("{_0}")]
+    InvalidPreimageKey(InvalidPreimageKeyType),
     /// Key not found.
-    #[error("Key not found.")]
+    #[display("Key not found.")]
     KeyNotFound,
     /// Buffer length mismatch.
-    #[error("Buffer length mismatch. Expected {0}, got {1}.")]
+    #[display("Buffer length mismatch. Expected {_0}, got {_1}.")]
     BufferLengthMismatch(usize, usize),
     /// Other errors.
-    #[error("Error in preimage server: {0}")]
+    #[display("Error in preimage server: {_0}")]
     Other(String),
+}
+
+impl From<IOError> for PreimageOracleError {
+    fn from(err: IOError) -> Self {
+        Self::IOError(err)
+    }
+}
+
+impl From<InvalidPreimageKeyType> for PreimageOracleError {
+    fn from(err: InvalidPreimageKeyType) -> Self {
+        Self::InvalidPreimageKey(err)
+    }
+}
+
+impl core::error::Error for PreimageOracleError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::IOError(err) => Some(err),
+            _ => None,
+        }
+    }
 }
 
 /// A [Result] type for the [PreimageOracleError] enum.
@@ -34,6 +54,8 @@ pub type PreimageOracleResult<T> = Result<T, PreimageOracleError>;
 /// Invalid [PreimageKeyType] error.
 ///
 /// [PreimageKeyType]: crate::key::PreimageKeyType
-#[derive(Error, Debug)]
-#[error("Invalid preimage key type")]
+#[derive(derive_more::Display, Debug)]
+#[display("Invalid preimage key type")]
 pub struct InvalidPreimageKeyType;
+
+impl core::error::Error for InvalidPreimageKeyType {}


### PR DESCRIPTION
### Description

Completely removes the [`thiserror`](https://github.com/dtolnay/thiserror) dependency, allowing us to publish our crates. Instead of deriving the [`core::error::Error`](https://doc.rust-lang.org/beta/core/error/trait.Error.html) type, we manually implement along with using [`derive_more::Display`](https://docs.rs/derive_more/latest/derive_more/derive.Display.html).