### PR TITLE
fix: tracing_subscriber problem in `kona-derive` tests

### DIFF
--- a/crates/derive/src/batch/span_batch/batch.rs
+++ b/crates/derive/src/batch/span_batch/batch.rs
@@ -480,7 +480,7 @@ mod tests {
     use op_alloy_consensus::{OpBlock, OpTxType};
     use op_alloy_genesis::ChainGenesis;
     use tracing::Level;
-    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+    use tracing_subscriber::layer::SubscriberExt;
 
     #[test]
     fn test_timestamp() {
@@ -526,7 +526,8 @@ mod tests {
     async fn test_check_batch_missing_l1_block_input() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig::default();
         let l1_blocks = vec![];
@@ -547,7 +548,8 @@ mod tests {
     async fn test_check_batches_is_empty() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig::default();
         let l1_blocks = vec![BlockInfo::default()];
@@ -568,7 +570,8 @@ mod tests {
     async fn test_eager_block_missing_origins() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig::default();
         let block = BlockInfo { number: 9, ..Default::default() };
@@ -595,7 +598,8 @@ mod tests {
     async fn test_check_batch_delta_inactive() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig { delta_time: Some(10), ..Default::default() };
         let block = BlockInfo { number: 10, timestamp: 9, ..Default::default() };
@@ -623,7 +627,8 @@ mod tests {
     async fn test_check_batch_out_of_order() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
@@ -651,7 +656,8 @@ mod tests {
     async fn test_check_batch_no_new_blocks() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
@@ -677,7 +683,8 @@ mod tests {
     async fn test_check_batch_misaligned_timestamp() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
@@ -704,7 +711,8 @@ mod tests {
     async fn test_check_batch_misaligned_without_overlap() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
@@ -731,7 +739,8 @@ mod tests {
     async fn test_check_batch_failed_to_fetch_l2_block() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
@@ -759,7 +768,8 @@ mod tests {
     async fn test_check_batch_parent_hash_fail() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
@@ -799,7 +809,8 @@ mod tests {
     async fn test_check_sequence_window_expired() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig { delta_time: Some(0), block_time: 10, ..Default::default() };
         let block = BlockInfo { number: 10, timestamp: 10, ..Default::default() };
@@ -841,7 +852,8 @@ mod tests {
     async fn test_starting_epoch_too_far_ahead() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -891,7 +903,8 @@ mod tests {
     async fn test_check_batch_epoch_hash_mismatch() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -951,7 +964,8 @@ mod tests {
     async fn test_need_more_l1_blocks() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -1003,7 +1017,8 @@ mod tests {
     async fn test_drop_batch_epoch_too_old() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -1059,7 +1074,8 @@ mod tests {
     async fn test_check_batch_exceeds_max_seq_drif() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -1114,7 +1130,8 @@ mod tests {
     async fn test_continuing_with_empty_batch() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -1172,7 +1189,8 @@ mod tests {
     async fn test_check_batch_exceeds_sequencer_time_drift() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -1240,7 +1258,8 @@ mod tests {
     async fn test_check_batch_empty_txs() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -1304,7 +1323,8 @@ mod tests {
     async fn test_check_batch_with_deposit_tx() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -1370,7 +1390,8 @@ mod tests {
     async fn test_check_batch_failed_to_fetch_payload() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -1422,7 +1443,8 @@ mod tests {
     async fn test_check_batch_failed_to_extract_l2_block_info() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = RollupConfig {
             seq_window_size: 100,
@@ -1490,7 +1512,8 @@ mod tests {
     async fn test_overlapped_blocks_origin_mismatch() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let payload_block_hash =
             b256!("0e2ee9abe94ee4514b170d7039d8151a7469d434a8575dbab5bd4187a27732dd");
@@ -1560,7 +1583,8 @@ mod tests {
     async fn test_check_batch_valid_with_genesis_epoch() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let payload_block_hash =
             b256!("0e2ee9abe94ee4514b170d7039d8151a7469d434a8575dbab5bd4187a27732dd");

--- a/crates/derive/src/stages/batch/batch_queue.rs
+++ b/crates/derive/src/stages/batch/batch_queue.rs
@@ -486,7 +486,7 @@ mod tests {
     use op_alloy_genesis::{ChainGenesis, MAX_RLP_BYTES_PER_CHANNEL_FJORD};
     use op_alloy_protocol::{L1BlockInfoBedrock, L1BlockInfoTx};
     use tracing::Level;
-    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+    use tracing_subscriber::layer::SubscriberExt;
 
     fn new_batch_reader() -> BatchReader {
         let file_contents =
@@ -836,7 +836,8 @@ mod tests {
     async fn test_holocene_derive_next_batch_future() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         // Construct a future single batch.
         let cfg = Arc::new(RollupConfig { holocene_time: Some(0), ..Default::default() });
@@ -958,7 +959,8 @@ mod tests {
     async fn test_next_batch_missing_origin() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let mut reader = new_batch_reader();
         let payload_block_hash =

--- a/crates/derive/src/stages/batch/batch_validator.rs
+++ b/crates/derive/src/stages/batch/batch_validator.rs
@@ -326,7 +326,7 @@ mod test {
     use op_alloy_genesis::RollupConfig;
     use op_alloy_protocol::{BlockInfo, L2BlockInfo};
     use tracing::Level;
-    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+    use tracing_subscriber::layer::SubscriberExt;
 
     #[tokio::test]
     async fn test_batch_validator_origin_behind_eof() {
@@ -546,7 +546,8 @@ mod test {
     async fn test_batch_validator_next_batch_sequence_window_expired() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = Arc::new(RollupConfig { seq_window_size: 5, ..Default::default() });
         let mut mock = TestNextBatchProvider::new(vec![]);
@@ -584,7 +585,8 @@ mod test {
     async fn test_batch_validator_next_batch_sequence_window_expired_advance_epoch() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let cfg = Arc::new(RollupConfig { seq_window_size: 5, ..Default::default() });
         let mut mock = TestNextBatchProvider::new(vec![]);

--- a/crates/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/derive/src/stages/channel/channel_assembler.rs
@@ -204,13 +204,14 @@ mod test {
     };
     use op_alloy_protocol::BlockInfo;
     use tracing::Level;
-    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+    use tracing_subscriber::layer::SubscriberExt;
 
     #[tokio::test]
     async fn test_assembler_channel_timeout() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let frames = [
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),
@@ -272,7 +273,8 @@ mod test {
     async fn test_assembler_already_built() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let frames = [
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),
@@ -310,7 +312,8 @@ mod test {
     async fn test_assembler_size_limit_exceeded_bedrock() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let mut frames = [
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),
@@ -344,7 +347,8 @@ mod test {
     async fn test_assembler_size_limit_exceeded_fjord() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let mut frames = [
             crate::frame!(0xFF, 0, vec![0xDD; 50], false),

--- a/crates/derive/src/stages/channel/channel_bank.rs
+++ b/crates/derive/src/stages/channel/channel_bank.rs
@@ -277,7 +277,7 @@ mod tests {
     use alloc::vec;
     use op_alloy_genesis::{BASE_MAINNET_CONFIG, OP_MAINNET_CONFIG};
     use tracing::Level;
-    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+    use tracing_subscriber::layer::SubscriberExt;
 
     #[test]
     fn test_try_read_channel_at_index_missing_channel() {
@@ -447,7 +447,8 @@ mod tests {
     fn test_ingest_invalid_frame() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let mock = TestNextFrameProvider::new(vec![]);
         let mut channel_bank = ChannelBank::new(Arc::new(RollupConfig::default()), mock);
@@ -531,7 +532,8 @@ mod tests {
     async fn test_channel_timeout() {
         let trace_store: TraceStorage = Default::default();
         let layer = CollectingLayer::new(trace_store.clone());
-        tracing_subscriber::Registry::default().with(layer).init();
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         const ROLLUP_CONFIGS: [RollupConfig; 2] = [OP_MAINNET_CONFIG, BASE_MAINNET_CONFIG];
 


### PR DESCRIPTION
This PR provides fix for tracing_subscriber initialization at `kona-derive` tests.
command to reproduce:
```
cd crates/derive; cargo test 
```
the result:
```
---- batch::span_batch::batch::tests::test_check_batch_exceeds_sequencer_time_drift stdout ----
thread 'batch::span_batch::batch::tests::test_check_batch_exceeds_sequencer_time_drift' panicked at .cargo/registry/src/index.crates.io-6f17d22bba15001f/tracing-subscriber-0.3.18/src/util.rs:91:14:
failed to set global default subscriber: SetGlobalDefaultError("a global default trace dispatcher has already been set")
...
  
test result: FAILED. 216 passed; 34 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.02s
```

with this fix:
```
test result: ok. 250 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.05s
```