### PR TITLE
chore(workspace): Update op-alloy Deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2769,9 +2769,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7c98055fd048073738df0cc6d6537e992a0d8828f39d99a469e870db126dbd"
+checksum = "f26c3b35b7b3e36d15e0563eebffe13c1d9ca16b7aaffcb6a64354633547e16b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2785,9 +2785,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-genesis"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d631e8113cf88d30e621022677209caa148a9ca3ccb590fd34bbd1c731e3aff3"
+checksum = "ccacc2efed3d60d98ea581bddb885df1c6c62a592e55de049cfefd94116112cd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2799,26 +2799,29 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-protocol"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b39574acb1873315e6bd89df174f6223e897188fb87eeea2ad1eda04f7d28eb"
+checksum = "f5f8e6ec6b91c6aaeb20860b455a52fd8e300acfe5d534e96e9073a24f853e74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "async-trait",
  "derive_more",
  "op-alloy-consensus",
  "op-alloy-genesis",
  "serde",
+ "tracing",
+ "unsigned-varint",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e3a47ea24cee189b4351be247fd138c68571704ee57060cf5a722502f44412c"
+checksum = "4b52ee59c86537cff83e8c7f2a6aa287a94f3608bb40c06d442aafd0c2e807a4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,10 +81,10 @@ alloy-rpc-types-engine = { version = "0.5.4", default-features = false }
 alloy-rpc-types-beacon = { version = "0.5.4", default-features = false }
 
 # OP Alloy
-op-alloy-genesis = { version = "0.5.1", default-features = false }
-op-alloy-protocol = { version = "0.5.1", default-features = false }
-op-alloy-consensus = { version = "0.5.1", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.5.1", default-features = false }
+op-alloy-genesis = { version = "0.5.2", default-features = false }
+op-alloy-protocol = { version = "0.5.2", default-features = false }
+op-alloy-consensus = { version = "0.5.2", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.5.2", default-features = false }
 
 # General
 lru = "0.12.4"


### PR DESCRIPTION
### Description

Updates `op-alloy-*` dependencies to `v0.5.2`.