### PR TITLE
chore(ci): Don't run `online` tests in CI

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -26,7 +26,14 @@ jobs:
         run: cargo generate-lockfile
       - name: cargo llvm-cov
         run: |
-          RUST_MIN_STACK=33554432 cargo llvm-cov nextest --locked --workspace --lcov --output-path lcov.info --features test-utils --profile ci && \
+          RUST_MIN_STACK=33554432 cargo llvm-cov nextest \
+            --locked \
+            --workspace \
+            --lcov \
+            --output-path lcov.info \
+            --features test-utils \
+            --profile ci \
+            -E '!test(test_online)' && \
             mv ./target/nextest/ci/junit.xml ./junit.xml
       - name: Record Rust version
         run: echo "RUST=$(rustc --version)" >> "$GITHUB_ENV"

--- a/.github/workflows/rust_ci.yaml
+++ b/.github/workflows/rust_ci.yaml
@@ -10,10 +10,7 @@ jobs:
   cargo-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    strategy:
-      matrix:
-        mode: ["online", "offline"]
-    name: test-${{ matrix.mode }}
+    name: test
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -27,12 +24,7 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: cargo test
-        run: |
-          if [[ ${{ contains(matrix.mode, 'online') }} == true ]]; then
-            just test-online
-          else
-            just test
-          fi
+        run: just test
   cargo-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
## Overview

Changes the test jobs in CI such that they don't run the online tests. These tests are very flaky now that our test RPC has started to rate-limit.