### PR TITLE
fix(client): Remove `executor` shadow in FCU retry

### DIFF
--- a/bin/client/src/l1/driver.rs
+++ b/bin/client/src/l1/driver.rs
@@ -213,8 +213,7 @@ where
                         });
 
                         // Retry the execution.
-                        let mut executor =
-                            self.new_executor(cfg, provider, hinter, handle_register);
+                        executor = self.new_executor(cfg, provider, hinter, handle_register);
                         match executor.execute_payload(attributes) {
                             Ok(Header { number, .. }) => *number,
                             Err(e) => {

--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ test-online:
   just test "-E 'test(test_online)'"
 
 # Run action tests for the client program on the native target
-action-tests test_name='Test_ProgramAction':
+action-tests test_name='Test_ProgramAction' *args='':
   #!/bin/bash
 
   just monorepo
@@ -42,7 +42,7 @@ action-tests test_name='Test_ProgramAction':
   export KONA_CLIENT_PATH="{{justfile_directory()}}/target/release-client-lto/kona"
 
   cd monorepo/op-e2e/actions/proofs && \
-    go test -run "{{test_name}}" -v -count=1 ./...
+    go test -run "{{test_name}}" {{args}} -count=1 ./...
 
 # Clean the action tests directory
 clean-actions:


### PR DESCRIPTION
## Overview

Fixes a bug caused by shadowing the `executor` variable when retrying a deposit-only payload execution post-Holocene. This bug was caught with the Holocene action tests.