### PR TITLE
chore(ci): Use `gotestsum` for action test job

### DIFF
--- a/.github/workflows/action_tests.yaml
+++ b/.github/workflows/action_tests.yaml
@@ -27,6 +27,10 @@ jobs:
           go-version: "1.22.7"
           cache-dependency-path: |
             monorepo/go.sum
+      - name: Setup gotestsum
+        uses: autero1/action-gotestsum@v2.0.0
+        with:
+          gotestsum_version: 1.12.0
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Run Actions Tests

--- a/justfile
+++ b/justfile
@@ -42,7 +42,7 @@ action-tests test_name='Test_ProgramAction' *args='':
   export KONA_CLIENT_PATH="{{justfile_directory()}}/target/release-client-lto/kona"
 
   cd monorepo/op-e2e/actions/proofs && \
-    go test -run "{{test_name}}" {{args}} -count=1 ./...
+    gotestsum --format=short-verbose -- -run "{{test_name}}" {{args}} -count=1 ./...
 
 # Clean the action tests directory
 clean-actions:


### PR DESCRIPTION
## Overview

Uses `gotestsum` for action tests CI. This makes the `stdout` stream of the job much, much smaller, which should speed up the job in the happy path. If a test fails, `gotestsum` will print the verbose output of _just_ the test(s) that fail.