### PR TITLE
fix(derive-alloy): changelog

### DIFF
--- a/crates/derive-alloy/CHANGELOG.md
+++ b/crates/derive-alloy/CHANGELOG.md
@@ -29,16 +29,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - release ([#715](https://github.com/anton-rs/kona/pull/715))
-
-## [0.0.1](https://github.com/anton-rs/kona/releases/tag/kona-derive-alloy-v0.0.1) - 2024-10-25
-
-### Added
-
-- remove thiserror ([#735](https://github.com/anton-rs/kona/pull/735))
-- *(derive)* `BatchProvider` multiplexed stage ([#726](https://github.com/anton-rs/kona/pull/726))
-- *(workspace)* Distribute pipeline, not providers ([#717](https://github.com/anton-rs/kona/pull/717))
-# Changelog
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
### Description

Small PR to fix the `kona-derive-alloy` `CHANGELOG` so release-plz doesn't keep overwriting changes.