### PR TITLE
chore(executor): Remove Upstream Utility

### DIFF
--- a/crates/executor/src/executor/util.rs
+++ b/crates/executor/src/executor/util.rs
@@ -2,51 +2,11 @@
 
 use crate::{constants::HOLOCENE_EXTRA_DATA_VERSION, ExecutorError, ExecutorResult};
 use alloc::vec::Vec;
-use alloy_consensus::{Eip658Value, Header, Receipt, ReceiptWithBloom};
+use alloy_consensus::Header;
 use alloy_eips::eip1559::BaseFeeParams;
-use alloy_primitives::{logs_bloom, Bytes, Log, B64};
-use op_alloy_consensus::{
-    OpDepositReceipt, OpDepositReceiptWithBloom, OpReceiptEnvelope, OpTxType,
-};
+use alloy_primitives::{Bytes, B64};
 use op_alloy_genesis::RollupConfig;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
-
-/// Constructs a [OpReceiptEnvelope] from a [Receipt] fields and [OpTxType].
-pub(crate) fn receipt_envelope_from_parts<'a>(
-    status: bool,
-    cumulative_gas_used: u128,
-    logs: impl IntoIterator<Item = &'a Log>,
-    tx_type: OpTxType,
-    deposit_nonce: Option<u64>,
-    deposit_receipt_version: Option<u64>,
-) -> OpReceiptEnvelope {
-    let logs = logs.into_iter().cloned().collect::<Vec<_>>();
-    let logs_bloom = logs_bloom(&logs);
-    let inner_receipt = Receipt { status: Eip658Value::Eip658(status), cumulative_gas_used, logs };
-    match tx_type {
-        OpTxType::Legacy => {
-            OpReceiptEnvelope::Legacy(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
-        }
-        OpTxType::Eip2930 => {
-            OpReceiptEnvelope::Eip2930(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
-        }
-        OpTxType::Eip1559 => {
-            OpReceiptEnvelope::Eip1559(ReceiptWithBloom { receipt: inner_receipt, logs_bloom })
-        }
-        OpTxType::Eip7702 => panic!("EIP-7702 is not supported"),
-        OpTxType::Deposit => {
-            let inner = OpDepositReceiptWithBloom {
-                receipt: OpDepositReceipt {
-                    inner: inner_receipt,
-                    deposit_nonce,
-                    deposit_receipt_version,
-                },
-                logs_bloom,
-            };
-            OpReceiptEnvelope::Deposit(inner)
-        }
-    }
-}
 
 /// Parse Holocene [Header] extra data.
 ///


### PR DESCRIPTION
### Description

Small PR to use the upstream receipt constructor in `op-alloy` added in https://github.com/alloy-rs/op-alloy/pull/165