### PR TITLE
chore: Derivation Import Cleanup

### DIFF
--- a/bin/client/src/l1/driver.rs
+++ b/bin/client/src/l1/driver.rs
@@ -3,35 +3,24 @@
 //!
 //! [OpPayloadAttributes]: op_alloy_rpc_types_engine::OpPayloadAttributes
 
-use super::OracleL1ChainProvider;
-use crate::{l2::OracleL2ChainProvider, BootInfo, FlushableCache, HintType};
 use alloc::{sync::Arc, vec::Vec};
-use alloy_consensus::{Header, Sealed};
-use alloy_primitives::B256;
 use anyhow::{anyhow, Result};
 use core::fmt::Debug;
-use kona_derive::{
-    attributes::StatefulAttributesBuilder,
-    errors::{PipelineErrorKind, ResetError},
-    pipeline::{DerivationPipeline, PipelineBuilder},
-    sources::EthereumDataSource,
-    stages::{
-        AttributesQueue, BatchProvider, BatchStream, ChannelProvider, ChannelReader, FrameQueue,
-        L1Retrieval, L1Traversal,
-    },
-    traits::{
-        ActivationSignal, BlobProvider, ChainProvider, L2ChainProvider, OriginProvider, Pipeline,
-        ResetSignal, Signal, SignalReceiver, StepResult,
-    },
-};
-use kona_executor::{KonaHandleRegister, StatelessL2BlockExecutor};
-use kona_mpt::{TrieHinter, TrieProvider};
-use kona_preimage::{CommsClient, PreimageKey, PreimageKeyType};
+use tracing::{error, info, warn};
+
+use alloy_consensus::{Header, Sealed};
+use alloy_primitives::B256;
 use op_alloy_consensus::OpTxType;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::{BatchValidationProvider, BlockInfo, L2BlockInfo};
 use op_alloy_rpc_types_engine::OpAttributesWithParent;
-use tracing::{error, info, warn};
+
+use kona_derive::prelude::*;
+use kona_executor::{KonaHandleRegister, StatelessL2BlockExecutor};
+use kona_mpt::{TrieHinter, TrieProvider};
+use kona_preimage::{CommsClient, PreimageKey, PreimageKeyType};
+
+use crate::{BootInfo, HintType, OracleL1ChainProvider, OracleL2ChainProvider};
 
 /// An oracle-backed derivation pipeline.
 pub type OraclePipeline<O, B> = DerivationPipeline<

--- a/bin/client/src/lib.rs
+++ b/bin/client/src/lib.rs
@@ -7,8 +7,10 @@
 extern crate alloc;
 
 pub mod l1;
+pub use l1::OracleL1ChainProvider;
 
 pub mod l2;
+pub use l2::OracleL2ChainProvider;
 
 mod hint;
 pub use hint::HintType;

--- a/crates/derive-alloy/src/lib.rs
+++ b/crates/derive-alloy/src/lib.rs
@@ -6,11 +6,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 
-#[cfg(any(test, feature = "test-utils"))]
-pub mod test_utils;
-#[cfg(any(test, feature = "test-utils"))]
-pub use test_utils::*;
-
 /// Re-export commonly used types and traits.
 pub mod prelude {
     pub use super::{
@@ -39,3 +34,6 @@ pub use blob_provider::{
     BlobSidecarProvider, OnlineBlobProvider, OnlineBlobProviderBuilder,
     OnlineBlobProviderWithFallback,
 };
+
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;

--- a/crates/derive-alloy/src/pipeline.rs
+++ b/crates/derive-alloy/src/pipeline.rs
@@ -1,14 +1,6 @@
 //! Helper to construct a [DerivationPipeline] using online types.
 
-use kona_derive::{
-    attributes::StatefulAttributesBuilder,
-    pipeline::{DerivationPipeline, PipelineBuilder},
-    sources::EthereumDataSource,
-    stages::{
-        AttributesQueue, BatchProvider, BatchStream, ChannelProvider, ChannelReader, FrameQueue,
-        L1Retrieval, L1Traversal,
-    },
-};
+use kona_derive::prelude::*;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::BlockInfo;
 use std::sync::Arc;
@@ -70,7 +62,6 @@ pub fn new_online_pipeline(
 mod tests {
     use super::*;
     use crate::OnlineBlobProvider;
-    use kona_derive::prelude::OriginProvider;
 
     #[test]
     fn test_new_online_pipeline() {

--- a/crates/derive/src/errors/mod.rs
+++ b/crates/derive/src/errors/mod.rs
@@ -1,4 +1,4 @@
-//! Error types for kona's derivation pipeline.
+//! Error types for the kona derivation pipeline.
 
 mod attributes;
 pub use attributes::BuilderError;


### PR DESCRIPTION
### Description

Small PR to clean up imports from `kona_derive` to use the `kona_derive::prelude`.