### PR TITLE
chore(ci): Trigger CI with an Empty Commit

### DIFF
--- a/.github/workflows/monorepo_pin_update.yaml
+++ b/.github/workflows/monorepo_pin_update.yaml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          token: ${{ secrets.GITHUB_TOKEN }} 
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: taiki-e/install-action@just
       - uses: dtolnay/rust-toolchain@stable
-      - name: Update Monorepo Commit 
+      - name: Update Monorepo Commit
         run: just update-monorepo
       - name: Create Pull Request
         id: cpr
@@ -32,10 +32,12 @@ jobs:
           title: '[BOT] Update Monorepo'
           body: |
             ### Description
-            
+
             Automated PR to update the monorepo commit.
           labels: |
             A-ci
             C-bot
           assignees: refcell
           draft: false
+      - name: Trigger CI Runs
+        run: just trigger

--- a/justfile
+++ b/justfile
@@ -158,3 +158,8 @@ monorepo:
 update-monorepo:
   [ ! -d monorepo ] && git clone https://github.com/ethereum-optimism/monorepo
   cd monorepo && git rev-parse HEAD > ../.monorepo
+
+# Force pushes an empty commit to the git branch to trigger CI
+trigger:
+  git commit --amend --no-edit
+  git push --force-with-lease


### PR DESCRIPTION
### Description

The github action to update the monorepo pin has left ci in a waiting status, not being triggered.

This PR appends a small step once the monorepo pin bot pr is open that force pushes an empty commit to the branch to trigger a ci run.

Since PRs are squash merged, this shouldn't have a noticeable effect, and should trigger ci to be run on PRs like #766.