### PR TITLE
chore(ci): Bump `asterisc` version

### DIFF
--- a/.github/workflows/client_host.yaml
+++ b/.github/workflows/client_host.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Build `asterisc`
         if: "!contains(matrix.target, 'native')"
         run: |
-          cd asterisc && git checkout v1.0.3-alpha1 && make build-rvgo
+          cd asterisc && git checkout v1.1.0 && make build-rvgo
           mv ./rvgo/bin/asterisc /usr/local/bin/
       - name: Set run environment
         run: |


### PR DESCRIPTION
## Overview

Bumps the `asterisc` version to `v1.1.0`. This is in preparation for a new alpha release, which will distribute the prestate created with the `asterisc-v1.1.0` binary.