### PR TITLE
chore(ci): Update monorepo pin to include Holocene action tests

### DIFF
--- a/.monorepo
+++ b/.monorepo
@@ -1,1 +1,1 @@
-1b4fda30ac55a9e234321974492caa156e1a954a
+gk/holocene-derivation-action-testing-stacked


### PR DESCRIPTION
## Overview

Temporarily updates the monocommit to @geoknee's branch, which includes the Holocene action tests. Once these are merged, we can go back to a commit sha on `develop`'s tree.