### PR TITLE
chore(ci): Update `monorepo` pin

### DIFF
--- a/.monorepo
+++ b/.monorepo
@@ -1,1 +1,1 @@
-gk/holocene-derivation-action-testing-stacked
+11f0298e1ebd25a0783d7cb798358dea04ecc235


### PR DESCRIPTION
## Overview

Updates the version of the monorepo, as the action tests for Holocene are now merged.