### PR TITLE
feat(derive): `From<BlobProviderError> for PipelineErrorKind`

### DIFF
--- a/bin/client/src/l1/driver.rs
+++ b/bin/client/src/l1/driver.rs
@@ -322,8 +322,7 @@ where
                                     self.l2_safe_head.block_info.number,
                                     self.pipeline.rollup_config.clone(),
                                 )
-                                .await
-                                .map_err(|e| PipelineError::Provider(e.to_string()).temp())?;
+                                .await?;
 
                             if matches!(e, ResetError::HoloceneActivation) {
                                 self.pipeline

--- a/bin/client/src/l1/driver.rs
+++ b/bin/client/src/l1/driver.rs
@@ -9,7 +9,7 @@ use crate::{
     l2::OracleL2ChainProvider,
     BootInfo, FlushableCache, HintType,
 };
-use alloc::{string::ToString, sync::Arc, vec::Vec};
+use alloc::{sync::Arc, vec::Vec};
 use alloy_consensus::{BlockBody, Header, Sealable, Sealed};
 use alloy_primitives::B256;
 use alloy_rlp::Decodable;

--- a/crates/derive-alloy/src/blob_provider.rs
+++ b/crates/derive-alloy/src/blob_provider.rs
@@ -1,13 +1,12 @@
 //! Contains an online implementation of the `BlobProvider` trait.
 
+use crate::{BeaconClient, OnlineBeaconClient};
 use alloy_eips::eip4844::{Blob, BlobTransactionSidecarItem};
 use alloy_rpc_types_beacon::sidecar::BlobData;
 use async_trait::async_trait;
 use kona_derive::{errors::BlobProviderError, sources::IndexedBlobHash, traits::BlobProvider};
 use op_alloy_protocol::BlockInfo;
 use tracing::warn;
-
-use crate::{BeaconClient, OnlineBeaconClient};
 
 /// An online implementation of the [BlobProvider] trait.
 #[derive(Debug, Clone)]

--- a/crates/derive/src/errors/sources.rs
+++ b/crates/derive/src/errors/sources.rs
@@ -1,6 +1,7 @@
 //! Error types for sources.
 
-use alloc::string::String;
+use alloc::string::{String, ToString};
+use super::{PipelineError, PipelineErrorKind};
 
 /// Blob Decoding Error
 #[derive(derive_more::Display, Debug, PartialEq, Eq)]
@@ -36,6 +37,17 @@ pub enum BlobProviderError {
     /// Error pertaining to the backend transport.
     #[display("{_0}")]
     Backend(String),
+}
+
+impl From<BlobProviderError> for PipelineErrorKind {
+    fn from(val: BlobProviderError) -> Self {
+        match val {
+            BlobProviderError::SidecarLengthMismatch(_, _) => PipelineError::Provider(val.to_string()).crit(),
+            BlobProviderError::SlotDerivation => PipelineError::Provider(val.to_string()).crit(),
+            BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
+            BlobProviderError::Backend(_) => PipelineError::Provider(val.to_string()).temp(),
+        }
+    }
 }
 
 impl From<BlobDecodingError> for BlobProviderError {

--- a/crates/derive/src/errors/sources.rs
+++ b/crates/derive/src/errors/sources.rs
@@ -1,7 +1,7 @@
 //! Error types for sources.
 
-use alloc::string::{String, ToString};
 use super::{PipelineError, PipelineErrorKind};
+use alloc::string::{String, ToString};
 
 /// Blob Decoding Error
 #[derive(derive_more::Display, Debug, PartialEq, Eq)]
@@ -42,7 +42,9 @@ pub enum BlobProviderError {
 impl From<BlobProviderError> for PipelineErrorKind {
     fn from(val: BlobProviderError) -> Self {
         match val {
-            BlobProviderError::SidecarLengthMismatch(_, _) => PipelineError::Provider(val.to_string()).crit(),
+            BlobProviderError::SidecarLengthMismatch(_, _) => {
+                PipelineError::Provider(val.to_string()).crit()
+            }
             BlobProviderError::SlotDerivation => PipelineError::Provider(val.to_string()).crit(),
             BlobProviderError::BlobDecoding(_) => PipelineError::Provider(val.to_string()).crit(),
             BlobProviderError::Backend(_) => PipelineError::Provider(val.to_string()).temp(),

--- a/crates/derive/src/sources/blobs.rs
+++ b/crates/derive/src/sources/blobs.rs
@@ -4,7 +4,7 @@ use crate::{
     errors::{BlobDecodingError, BlobProviderError, PipelineError, PipelineResult},
     traits::{AsyncIterator, BlobProvider, ChainProvider},
 };
-use alloc::{boxed::Box, format, string::ToString, vec, vec::Vec};
+use alloc::{boxed::Box, string::ToString, vec, vec::Vec};
 use alloy_consensus::{Transaction, TxEip4844Variant, TxEnvelope, TxType};
 use alloy_eips::eip4844::{Blob, BYTES_PER_BLOB, VERSIONED_HASH_VERSION_KZG};
 use alloy_primitives::{Address, Bytes, B256};

--- a/crates/derive/src/sources/blobs.rs
+++ b/crates/derive/src/sources/blobs.rs
@@ -361,13 +361,7 @@ where
     type Item = Bytes;
 
     async fn next(&mut self) -> PipelineResult<Self::Item> {
-        if self.load_blobs().await.is_err() {
-            return Err(PipelineError::Provider(format!(
-                "Failed to load blobs from stream: {}",
-                self.block_ref.hash
-            ))
-            .temp());
-        }
+        self.load_blobs().await?;
 
         let next_data = match self.next_data() {
             Ok(d) => d,

--- a/crates/derive/src/test_utils/blob_provider.rs
+++ b/crates/derive/src/test_utils/blob_provider.rs
@@ -1,12 +1,11 @@
 //! An implementation of the [BlobProvider] trait for tests.
 
+use crate::{errors::BlobProviderError, sources::IndexedBlobHash, traits::BlobProvider};
 use alloc::{boxed::Box, vec::Vec};
 use alloy_eips::eip4844::Blob;
 use alloy_primitives::{map::HashMap, B256};
 use async_trait::async_trait;
 use op_alloy_protocol::BlockInfo;
-
-use crate::{errors::BlobProviderError, sources::IndexedBlobHash, traits::BlobProvider};
 
 /// A mock blob provider for testing.
 #[derive(Debug, Clone, Default)]

--- a/crates/derive/src/traits/data_sources.rs
+++ b/crates/derive/src/traits/data_sources.rs
@@ -1,7 +1,7 @@
 //! Contains traits that describe the functionality of various data sources used in the derivation
 //! pipeline's stages.
 
-use crate::{errors::PipelineResult, sources::IndexedBlobHash};
+use crate::{errors::{PipelineErrorKind, PipelineResult}, sources::IndexedBlobHash};
 use alloc::{boxed::Box, fmt::Debug, string::ToString, vec::Vec};
 use alloy_eips::eip4844::Blob;
 use alloy_primitives::Bytes;
@@ -13,7 +13,7 @@ use op_alloy_protocol::BlockInfo;
 #[async_trait]
 pub trait BlobProvider {
     /// The error type for the [BlobProvider].
-    type Error: Display + ToString;
+    type Error: Display + ToString + Into<PipelineErrorKind>;
 
     /// Fetches blobs for a given block ref and the blob hashes.
     async fn get_blobs(

--- a/crates/derive/src/traits/data_sources.rs
+++ b/crates/derive/src/traits/data_sources.rs
@@ -1,7 +1,10 @@
 //! Contains traits that describe the functionality of various data sources used in the derivation
 //! pipeline's stages.
 
-use crate::{errors::{PipelineErrorKind, PipelineResult}, sources::IndexedBlobHash};
+use crate::{
+    errors::{PipelineErrorKind, PipelineResult},
+    sources::IndexedBlobHash,
+};
 use alloc::{boxed::Box, fmt::Debug, string::ToString, vec::Vec};
 use alloy_eips::eip4844::Blob;
 use alloy_primitives::Bytes;


### PR DESCRIPTION
## Overview

Enforces that the `BlobProvider` trait impls use an `Error` type that can be converted to `PipelineErrorKind`.