### PR TITLE
feat(TrieProvider): Abstract TrieNode retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "arrayvec",
  "derive_more",
  "nybbles",
+ "serde",
  "smallvec",
  "tracing",
 ]
@@ -726,6 +727,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "async-stream"
@@ -2367,6 +2371,7 @@ dependencies = [
  "proptest",
  "rand",
  "reqwest",
+ "serde",
  "tokio",
  "tracing-subscriber",
 ]
@@ -2742,6 +2747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95f06be0417d97f81fe4e5c86d7d01b392655a9cac9c19a848aa033e18937b23"
 dependencies = [
  "const-hex",
+ "serde",
  "smallvec",
 ]
 
@@ -3980,6 +3986,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/crates/executor/benches/execution.rs
+++ b/crates/executor/benches/execution.rs
@@ -8,7 +8,7 @@ use alloy_rpc_types_engine::PayloadAttributes;
 use anyhow::{anyhow, Result};
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
 use kona_executor::StatelessL2BlockExecutor;
-use kona_mpt::{NoopTrieHinter, TrieProvider};
+use kona_mpt::{NoopTrieHinter, TrieNode, TrieProvider};
 use op_alloy_genesis::{RollupConfig, OP_MAINNET_BASE_FEE_PARAMS};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use pprof::criterion::{Output, PProfProfiler};
@@ -37,11 +37,16 @@ impl TestdataTrieProvider {
 impl TrieProvider for TestdataTrieProvider {
     type Error = anyhow::Error;
 
-    fn trie_node_preimage(&self, key: B256) -> Result<Bytes> {
-        self.preimages
-            .get(&key)
-            .cloned()
-            .ok_or_else(|| anyhow!("Preimage not found for key: {}", key))
+    fn trie_node_by_hash(&self, key: B256) -> Result<TrieNode> {
+        TrieNode::decode(
+            &mut self
+                .preimages
+                .get(&key)
+                .cloned()
+                .ok_or_else(|| anyhow!("Preimage not found for key: {}", key))?
+                .as_ref(),
+        )
+        .map_err(Into::into)
     }
 
     fn bytecode_by_hash(&self, code_hash: B256) -> Result<Bytes> {

--- a/crates/executor/src/executor/mod.rs
+++ b/crates/executor/src/executor/mod.rs
@@ -456,7 +456,7 @@ mod test {
     use alloy_rlp::Decodable;
     use alloy_rpc_types_engine::PayloadAttributes;
     use anyhow::{anyhow, Result};
-    use kona_mpt::NoopTrieHinter;
+    use kona_mpt::{NoopTrieHinter, TrieNode};
     use op_alloy_genesis::OP_MAINNET_BASE_FEE_PARAMS;
     use serde::Deserialize;
     use std::collections::HashMap;
@@ -483,11 +483,16 @@ mod test {
     impl TrieProvider for TestdataTrieProvider {
         type Error = anyhow::Error;
 
-        fn trie_node_preimage(&self, key: B256) -> Result<Bytes> {
-            self.preimages
-                .get(&key)
-                .cloned()
-                .ok_or_else(|| anyhow!("Preimage not found for key: {}", key))
+        fn trie_node_by_hash(&self, key: B256) -> Result<TrieNode> {
+            TrieNode::decode(
+                &mut self
+                    .preimages
+                    .get(&key)
+                    .cloned()
+                    .ok_or_else(|| anyhow!("Preimage not found for key: {}", key))?
+                    .as_ref(),
+            )
+            .map_err(Into::into)
         }
 
         fn bytecode_by_hash(&self, code_hash: B256) -> Result<Bytes> {

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 [dependencies]
 # General
 derive_more = { workspace = true, features = ["full"] }
+serde = { workspace = true, optional = true, features = ["derive", "alloc"] }
 
 # Revm + Alloy
 alloy-rlp.workspace = true
@@ -37,6 +38,14 @@ tokio = { workspace = true, features = ["full"] }
 criterion = { workspace = true, features = ["html_reports"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 pprof = { workspace = true, features = ["criterion", "flamegraph", "frame-pointer"] }
+
+[features]
+default = ["serde"]
+serde = [
+    "dep:serde",
+    "alloy-primitives/serde",
+    "alloy-trie/serde"
+]
 
 [[bench]]
 name = "trie_node"

--- a/crates/mpt/src/list_walker.rs
+++ b/crates/mpt/src/list_walker.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloc::{collections::VecDeque, string::ToString, vec};
 use alloy_primitives::{Bytes, B256};
-use alloy_rlp::{Decodable, EMPTY_STRING_CODE};
+use alloy_rlp::EMPTY_STRING_CODE;
 use core::marker::PhantomData;
 
 /// A [OrderedListWalker] allows for traversing over a Merkle Patricia Trie containing a derivable
@@ -132,11 +132,9 @@ where
     where
         T: Into<B256>,
     {
-        let preimage = fetcher
-            .trie_node_preimage(hash.into())
-            .map_err(|e| TrieNodeError::Provider(e.to_string()))?;
-        TrieNode::decode(&mut preimage.as_ref())
-            .map_err(TrieNodeError::RLPError)
+        fetcher
+            .trie_node_by_hash(hash.into())
+            .map_err(|e| TrieNodeError::Provider(e.to_string()))
             .map_err(Into::into)
     }
 }
@@ -176,7 +174,7 @@ mod test {
     use alloy_consensus::{ReceiptEnvelope, TxEnvelope};
     use alloy_primitives::keccak256;
     use alloy_provider::network::eip2718::Decodable2718;
-    use alloy_rlp::Encodable;
+    use alloy_rlp::{Decodable, Encodable};
 
     #[tokio::test]
     async fn test_online_list_walker_receipts() {

--- a/crates/mpt/src/noop.rs
+++ b/crates/mpt/src/noop.rs
@@ -1,7 +1,7 @@
 //! Trait implementations for `kona-mpt` traits that are effectively a no-op.
 //! Providers trait implementations for downstream users who do not require hinting.
 
-use crate::{TrieHinter, TrieProvider};
+use crate::{TrieHinter, TrieNode, TrieProvider};
 use alloc::string::String;
 use alloy_consensus::Header;
 use alloy_primitives::{Address, Bytes, B256, U256};
@@ -13,8 +13,8 @@ pub struct NoopTrieProvider;
 impl TrieProvider for NoopTrieProvider {
     type Error = String;
 
-    fn trie_node_preimage(&self, _key: B256) -> Result<Bytes, Self::Error> {
-        Ok(Bytes::new())
+    fn trie_node_by_hash(&self, _key: B256) -> Result<TrieNode, Self::Error> {
+        Ok(TrieNode::Empty)
     }
 
     fn bytecode_by_hash(&self, _code_hash: B256) -> Result<Bytes, Self::Error> {

--- a/crates/mpt/src/traits.rs
+++ b/crates/mpt/src/traits.rs
@@ -1,6 +1,7 @@
 //! Contains the [TrieProvider] trait for fetching trie node preimages, contract bytecode, and
 //! headers.
 
+use crate::TrieNode;
 use alloc::string::ToString;
 use alloy_consensus::Header;
 use alloy_primitives::{Address, Bytes, B256, U256};
@@ -18,11 +19,11 @@ pub trait TrieProvider {
     /// - `key`: The key of the trie node to fetch.
     ///
     /// ## Returns
-    /// - Ok(Bytes): The trie node preimage.
+    /// - Ok(TrieNode): The trie node preimage.
     /// - Err(anyhow::Error): If the trie node preimage could not be fetched.
     ///
     /// [TrieDB]: crate::TrieDB
-    fn trie_node_preimage(&self, key: B256) -> Result<Bytes, Self::Error>;
+    fn trie_node_by_hash(&self, key: B256) -> Result<TrieNode, Self::Error>;
 
     /// Fetches the preimage of the bytecode hash provided.
     ///


### PR DESCRIPTION
This PR refactors the `TrieProvider` to change the the method for fetching trie node data into one that provides `TrieNode` instances instead of raw rlp-encoded bytes:
**Before**
```rust
fn trie_node_preimage(&self, key: B256) -> Result<Bytes, Self::Error>;
```
**After**
```rust
fn trie_node_by_hash(&self, key: B256) -> Result<TrieNode, Self::Error>;
```

This allows `TrieProvider` implementations to abstract away the details of how the required instance can be created and authenticated (i.e. through RLP decoding pre-image oracle answers on-demand or otherwise). This is useful for providing entire trees as query answers, instead of single nodes with blinded children.