### PR TITLE
chore: Dispatch book build without cache

### DIFF
--- a/.github/workflows/book.yaml
+++ b/.github/workflows/book.yaml
@@ -1,5 +1,6 @@
 name: Book Deployment
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -11,13 +12,8 @@ jobs:
       deployments: write
     name: Publish to GitHub Pages
     steps:
-      - name: Checkout sources
-        uses: actions/checkout@v4
-      - name: Install Rust stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: Setup mdbook
         run: |
           cargo install mdbook mdbook-mermaid mdbook-template

--- a/.github/workflows/book.yaml
+++ b/.github/workflows/book.yaml
@@ -26,3 +26,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book
+          mdbook-version: '0.4.40'


### PR DESCRIPTION
### Description

Touches up the kona book workflow to allow for manual dispatches