### PR TITLE
nit(mpt): Remove unnecessary `collapse_if_possible` call

### DIFF
--- a/crates/mpt/src/node.rs
+++ b/crates/mpt/src/node.rs
@@ -437,11 +437,10 @@ impl TrieNode {
                     // If the child node is empty, convert the extension into an empty node.
                     *self = Self::Empty;
                 }
-                Self::Blinded { .. } => {
-                    node.unblind(fetcher)?;
-                    self.collapse_if_possible(fetcher, hinter)?;
+                _ => {
+                    // If the child is a (blinded?) branch then no need for collapse
+                    // because deletion did not collapse the (blinded?) branch
                 }
-                _ => {}
             },
             Self::Branch { stack } => {
                 // Count non-empty children


### PR DESCRIPTION
This aim of this PR is to remove a very subtle yet unused `unblind` call to prevent access to unused trie nodes. Such additional access, while having minor performance impact, prevents the delegation of execution witness generation to external clients that retrieve the minimum required trie nodes, such as [zeth](https://github.com/risc0/zeth).

The PR modifies `collapse_if_possible` to avoid attempting to collapse the blinded child of an extension node. The reason is that because we assume the trie is correctly constructed prior to any execution, there is no need to unblind the child of the extension (which must be a branch) to attempt further collapse, because the execution did not unblind this child already and therefore did not perform any reads/writes to it.