### PR TITLE
chore(workspace): Migrate back to `thiserror` v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -164,7 +164,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -241,7 +241,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",
@@ -316,7 +316,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "serde",
  "serde_with",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -376,7 +376,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -449,7 +449,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tower",
  "tracing",
@@ -1119,7 +1119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb11bd1378bf3731b182997b40cefe00aba6a6cc74042c8318c1b271d3badf7"
 dependencies = [
  "nix 0.27.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -1141,15 +1141,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1389,7 +1380,6 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -2307,7 +2297,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "async-trait",
  "cfg-if",
- "derive_more",
  "kona-common",
  "kona-common-proc",
  "kona-derive",
@@ -2324,6 +2313,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin",
+ "thiserror 2.0.3",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2333,8 +2323,8 @@ name = "kona-common"
 version = "0.0.4"
 dependencies = [
  "cfg-if",
- "derive_more",
  "linked_list_allocator",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -2361,7 +2351,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "async-trait",
  "brotli",
- "derive_more",
  "miniz_oxide",
  "op-alloy-consensus",
  "op-alloy-genesis",
@@ -2371,6 +2360,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2384,12 +2374,12 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "async-trait",
- "derive_more",
  "kona-derive",
  "op-alloy-consensus",
  "op-alloy-genesis",
  "op-alloy-protocol",
  "op-alloy-rpc-types-engine",
+ "thiserror 2.0.3",
  "tracing",
 ]
 
@@ -2404,7 +2394,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "anyhow",
  "criterion",
- "derive_more",
  "kona-mpt",
  "op-alloy-consensus",
  "op-alloy-genesis",
@@ -2414,6 +2403,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
+ "thiserror 2.0.3",
  "tracing",
 ]
 
@@ -2468,12 +2458,12 @@ dependencies = [
  "alloy-trie",
  "anyhow",
  "criterion",
- "derive_more",
  "pprof",
  "proptest",
  "rand",
  "reqwest",
  "serde",
+ "thiserror 2.0.3",
  "tokio",
  "tracing-subscriber",
 ]
@@ -2484,11 +2474,11 @@ version = "0.0.4"
 dependencies = [
  "alloy-primitives",
  "async-trait",
- "derive_more",
  "kona-common",
  "os_pipe",
  "rkyv",
  "serde",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
 ]
@@ -3084,7 +3074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -3189,7 +3179,7 @@ dependencies = [
  "smallvec",
  "symbolic-demangle",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4330,7 +4320,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -4338,6 +4337,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4654,12 +4664,6 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ sha2 = { version = "0.10.8", default-features = false }
 c-kzg = { version = "1.0.3", default-features = false }
 anyhow = { version = "1.0.89", default-features = false }
 futures = { version = "0.3.30", default-features = false }
-derive_more = { version = "1.0.0", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 
 # Tracing
 tracing-loki = "0.2.5"

--- a/bin/client/Cargo.toml
+++ b/bin/client/Cargo.toml
@@ -42,7 +42,7 @@ cfg-if.workspace = true
 tracing.workspace = true
 serde_json.workspace = true
 async-trait.workspace = true
-derive_more = { workspace = true, features = ["full"] }
+thiserror.workspace = true
 
 # `tracing-subscriber` feature dependencies
 tracing-subscriber = { workspace = true, optional = true, features = ["fmt"] }

--- a/bin/client/src/errors.rs
+++ b/bin/client/src/errors.rs
@@ -1,42 +1,40 @@
 //! Error types for the client program.
 
 use alloc::string::{String, ToString};
-use derive_more::derive::Display;
+use thiserror::Error;
 use kona_derive::errors::{PipelineError, PipelineErrorKind};
 use kona_mpt::OrderedListWalkerError;
 use kona_preimage::errors::PreimageOracleError;
 use op_alloy_protocol::{FromBlockError, OpBlockConversionError};
 
 /// Error from an oracle-backed provider.
-#[derive(Display, Debug)]
+#[derive(Error, Debug)]
 pub enum OracleProviderError {
     /// Requested block number is past the chain head.
-    #[display("Block number ({_0}) past chain head ({_1})")]
+    #[error("Block number ({0}) past chain head ({_1})")]
     BlockNumberPastHead(u64, u64),
     /// Preimage oracle error.
-    #[display("Preimage oracle error: {_0}")]
+    #[error("Preimage oracle error: {0}")]
     Preimage(PreimageOracleError),
     /// List walker error.
-    #[display("Trie walker error: {_0}")]
+    #[error("Trie walker error: {0}")]
     TrieWalker(OrderedListWalkerError),
     /// BlockInfo error.
-    #[display("From block error: {_0}")]
+    #[error("From block error: {0}")]
     BlockInfo(FromBlockError),
     /// Op Block conversion error.
-    #[display("Op block conversion error: {_0}")]
+    #[error("Op block conversion error: {0}")]
     OpBlockConversion(OpBlockConversionError),
     /// Error decoding or encoding RLP.
-    #[display("RLP error: {_0}")]
+    #[error("RLP error: {0}")]
     Rlp(alloy_rlp::Error),
     /// Slice conversion error.
-    #[display("Slice conversion error: {_0}")]
+    #[error("Slice conversion error: {0}")]
     SliceConversion(core::array::TryFromSliceError),
     /// Serde error.
-    #[display("Serde error: {_0}")]
+    #[error("Serde error: {0}")]
     Serde(serde_json::Error),
 }
-
-impl core::error::Error for OracleProviderError {}
 
 impl From<OracleProviderError> for PipelineErrorKind {
     fn from(val: OracleProviderError) -> Self {
@@ -48,8 +46,6 @@ impl From<OracleProviderError> for PipelineErrorKind {
 }
 
 /// Error parsing a hint.
-#[derive(Display, Debug)]
-#[display("Hint parsing error: {_0}")]
+#[derive(Error, Debug)]
+#[error("Hint parsing error: {_0}")]
 pub struct HintParsingError(pub String);
-
-impl core::error::Error for HintParsingError {}

--- a/bin/client/src/errors.rs
+++ b/bin/client/src/errors.rs
@@ -1,11 +1,11 @@
 //! Error types for the client program.
 
 use alloc::string::{String, ToString};
-use thiserror::Error;
 use kona_derive::errors::{PipelineError, PipelineErrorKind};
 use kona_mpt::OrderedListWalkerError;
 use kona_preimage::errors::PreimageOracleError;
 use op_alloy_protocol::{FromBlockError, OpBlockConversionError};
+use thiserror::Error;
 
 /// Error from an oracle-backed provider.
 #[derive(Error, Debug)]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -13,5 +13,5 @@ workspace = true
 
 [dependencies]
 cfg-if.workspace = true
-derive_more = { workspace = true, features = ["full"] }
+thiserror.workspace = true
 linked_list_allocator.workspace = true

--- a/crates/common/src/errors.rs
+++ b/crates/common/src/errors.rs
@@ -1,11 +1,11 @@
 //! Errors for the `kona-common` crate.
 
-/// An error that can occur when reading from or writing to a file descriptor.
-#[derive(derive_more::Display, Debug, PartialEq, Eq)]
-#[display("IO error (errno: {_0})")]
-pub struct IOError(pub i32);
+use thiserror::Error;
 
-impl core::error::Error for IOError {}
+/// An error that can occur when reading from or writing to a file descriptor.
+#[derive(Error, Debug, PartialEq, Eq)]
+#[error("IO error (errno: {_0})")]
+pub struct IOError(pub i32);
 
 /// A [Result] type for the [IOError].
 pub type IOResult<T> = Result<T, IOError>;

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -31,7 +31,7 @@ tracing.workspace = true
 miniz_oxide.workspace = true
 async-trait.workspace = true
 alloc-no-stdlib.workspace = true
-derive_more = { workspace = true, features = ["full"] }
+thiserror.workspace = true
 
 # `serde` feature dependencies
 serde = { workspace = true, optional = true, features = ["derive"] }

--- a/crates/derive/src/errors/attributes.rs
+++ b/crates/derive/src/errors/attributes.rs
@@ -3,32 +3,31 @@
 use alloc::string::String;
 use alloy_eips::BlockNumHash;
 use alloy_primitives::B256;
+use thiserror::Error;
 
 /// An [AttributesBuilder] Error.
 ///
 /// [AttributesBuilder]: crate::traits::AttributesBuilder
-#[derive(derive_more::Display, Clone, Debug, PartialEq, Eq)]
+#[derive(Error, Clone, Debug, PartialEq, Eq)]
 pub enum BuilderError {
     /// Mismatched blocks.
-    #[display("Block mismatch. Expected {_0:?}, got {_1:?}")]
+    #[error("Block mismatch. Expected {0:?}, got {1:?}")]
     BlockMismatch(BlockNumHash, BlockNumHash),
     /// Mismatched blocks for the start of an Epoch.
-    #[display("Block mismatch on epoch reset. Expected {_0:?}, got {_1:?}")]
+    #[error("Block mismatch on epoch reset. Expected {0:?}, got {1:?}")]
     BlockMismatchEpochReset(BlockNumHash, BlockNumHash, B256),
     /// [SystemConfig] update failed.
     ///
     /// [SystemConfig]: op_alloy_genesis::SystemConfig
-    #[display("System config update failed")]
+    #[error("System config update failed")]
     SystemConfigUpdate,
     /// Broken time invariant between L2 and L1.
-    #[display("Time invariant broken. L1 origin: {_0:?} | Next L2 time: {_1} | L1 block: {_2:?} | L1 timestamp {_3:?}")]
+    #[error("Time invariant broken. L1 origin: {0:?} | Next L2 time: {1} | L1 block: {2:?} | L1 timestamp {3:?}")]
     BrokenTimeInvariant(BlockNumHash, u64, BlockNumHash, u64),
     /// Attributes unavailable.
-    #[display("Attributes unavailable")]
+    #[error("Attributes unavailable")]
     AttributesUnavailable,
     /// A custom error.
-    #[display("Error in attributes builder: {_0}")]
+    #[error("Error in attributes builder: {0}")]
     Custom(String),
 }
-
-impl core::error::Error for BuilderError {}

--- a/crates/derive/src/errors/pipeline.rs
+++ b/crates/derive/src/errors/pipeline.rs
@@ -5,6 +5,7 @@ use alloc::string::String;
 use alloy_primitives::B256;
 use op_alloy_genesis::system::SystemConfigUpdateError;
 use op_alloy_protocol::{DepositError, SpanBatchError};
+use thiserror::Error;
 
 /// [crate::ensure] is a short-hand for bubbling up errors in the case of a condition not being met.
 #[macro_export]
@@ -17,17 +18,17 @@ macro_rules! ensure {
 }
 
 /// A top level filter for [PipelineError] that sorts by severity.
-#[derive(derive_more::Display, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum PipelineErrorKind {
     /// A temporary error.
-    #[display("Temporary error: {_0}")]
-    Temporary(PipelineError),
+    #[error("Temporary error: {0}")]
+    Temporary(#[source] PipelineError),
     /// A critical error.
-    #[display("Critical error: {_0}")]
-    Critical(PipelineError),
+    #[error("Critical error: {0}")]
+    Critical(#[source] PipelineError),
     /// A reset error.
-    #[display("Pipeline reset: {_0}")]
-    Reset(ResetError),
+    #[error("Pipeline reset: {0}")]
+    Reset(#[source] ResetError),
 }
 
 impl From<ResetError> for PipelineErrorKind {
@@ -36,105 +37,73 @@ impl From<ResetError> for PipelineErrorKind {
     }
 }
 
-impl core::error::Error for PipelineErrorKind {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::Temporary(err) => Some(err),
-            Self::Critical(err) => Some(err),
-            Self::Reset(err) => Some(err),
-        }
-    }
-}
-
 /// An error encountered during the processing.
-#[derive(derive_more::Display, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum PipelineError {
     /// There is no data to read from the channel bank.
-    #[display("EOF")]
+    #[error("EOF")]
     Eof,
     /// There is not enough data to complete the processing of the stage. If the operation is
     /// re-tried, more data will come in allowing the pipeline to progress, or eventually a
     /// [PipelineError::Eof] will be encountered.
-    #[display("Not enough data")]
+    #[error("Not enough data")]
     NotEnoughData,
     /// No channels are available in the [ChannelProvider].
     ///
     /// [ChannelProvider]: crate::stages::ChannelProvider
-    #[display("The channel provider is empty")]
+    #[error("The channel provider is empty")]
     ChannelProviderEmpty,
     /// The channel has already been built by the [ChannelAssembler] stage.
     ///
     /// [ChannelAssembler]: crate::stages::ChannelAssembler
-    #[display("Channel already built")]
+    #[error("Channel already built")]
     ChannelAlreadyBuilt,
     /// Failed to find channel in the [ChannelProvider].
     ///
     /// [ChannelProvider]: crate::stages::ChannelProvider
-    #[display("Channel not found in channel provider")]
+    #[error("Channel not found in channel provider")]
     ChannelNotFound,
     /// No channel returned by the [ChannelReader] stage.
     ///
     /// [ChannelReader]: crate::stages::ChannelReader
-    #[display("The channel reader has no channel available")]
+    #[error("The channel reader has no channel available")]
     ChannelReaderEmpty,
     /// The [BatchQueue] is empty.
     ///
     /// [BatchQueue]: crate::stages::BatchQueue
-    #[display("The batch queue has no batches available")]
+    #[error("The batch queue has no batches available")]
     BatchQueueEmpty,
     /// Missing L1 origin.
-    #[display("Missing L1 origin from previous stage")]
+    #[error("Missing L1 origin from previous stage")]
     MissingOrigin,
     /// Missing data from [L1Retrieval].
     ///
     /// [L1Retrieval]: crate::stages::L1Retrieval
-    #[display("L1 Retrieval missing data")]
+    #[error("L1 Retrieval missing data")]
     MissingL1Data,
     /// Invalid batch type passed.
-    #[display("Invalid batch type passed to stage")]
+    #[error("Invalid batch type passed to stage")]
     InvalidBatchType,
     /// Invalid batch validity variant.
-    #[display("Invalid batch validity")]
+    #[error("Invalid batch validity")]
     InvalidBatchValidity,
     /// [SystemConfig] update error.
     ///
     /// [SystemConfig]: op_alloy_genesis::SystemConfig
-    #[display("Error updating system config: {_0}")]
+    #[error("Error updating system config: {0}")]
     SystemConfigUpdate(SystemConfigUpdateError),
     /// Attributes builder error variant, with [BuilderError].
-    #[display("Attributes builder error: {_0}")]
-    AttributesBuilder(BuilderError),
+    #[error("Attributes builder error: {0}")]
+    AttributesBuilder(#[from] BuilderError),
     /// [PipelineEncodingError] variant.
-    #[display("Decode error: {_0}")]
-    BadEncoding(PipelineEncodingError),
+    #[error("Decode error: {0}")]
+    BadEncoding(#[from] PipelineEncodingError),
     /// The data source can no longer provide any more data.
-    #[display("Data source exhausted")]
+    #[error("Data source exhausted")]
     EndOfSource,
     /// Provider error variant.
-    #[display("Blob provider error: {_0}")]
+    #[error("Blob provider error: {0}")]
     Provider(String),
-}
-
-impl From<BuilderError> for PipelineError {
-    fn from(err: BuilderError) -> Self {
-        Self::AttributesBuilder(err)
-    }
-}
-
-impl From<PipelineEncodingError> for PipelineError {
-    fn from(err: PipelineEncodingError) -> Self {
-        Self::BadEncoding(err)
-    }
-}
-
-impl core::error::Error for PipelineError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::AttributesBuilder(err) => Some(err),
-            Self::BadEncoding(err) => Some(err),
-            _ => None,
-        }
-    }
 }
 
 impl PipelineError {
@@ -150,41 +119,33 @@ impl PipelineError {
 }
 
 /// A reset error
-#[derive(derive_more::Display, Clone, Debug, Eq, PartialEq)]
+#[derive(Error, Clone, Debug, Eq, PartialEq)]
 pub enum ResetError {
     /// The batch has a bad parent hash.
     /// The first argument is the expected parent hash, and the second argument is the actual
     /// parent hash.
-    #[display("Bad parent hash: expected {_0}, got {_1}")]
+    #[error("Bad parent hash: expected {0}, got {1}")]
     BadParentHash(B256, B256),
     /// The batch has a bad timestamp.
     /// The first argument is the expected timestamp, and the second argument is the actual
     /// timestamp.
-    #[display("Bad timestamp: expected {_0}, got {_1}")]
+    #[error("Bad timestamp: expected {0}, got {1}")]
     BadTimestamp(u64, u64),
     /// L1 origin mismatch.
-    #[display("L1 origin mismatch. Expected {_0:?}, got {_1:?}")]
+    #[error("L1 origin mismatch. Expected {0:?}, got {1:?}")]
     L1OriginMismatch(u64, u64),
     /// The stage detected a block reorg.
     /// The first argument is the expected block hash.
     /// The second argument is the parent_hash of the next l1 origin block.
-    #[display("L1 reorg detected: expected {_0}, got {_1}")]
+    #[error("L1 reorg detected: expected {0}, got {1}")]
     ReorgDetected(B256, B256),
     /// Attributes builder error variant, with [BuilderError].
-    #[display("Attributes builder error: {_0}")]
-    AttributesBuilder(BuilderError),
+    #[error("Attributes builder error: {0}")]
+    AttributesBuilder(#[from] BuilderError),
     /// A Holocene activation temporary error.
-    #[display("Holocene activation reset")]
+    #[error("Holocene activation reset")]
     HoloceneActivation,
 }
-
-impl From<BuilderError> for ResetError {
-    fn from(err: BuilderError) -> Self {
-        Self::AttributesBuilder(err)
-    }
-}
-
-impl core::error::Error for ResetError {}
 
 impl ResetError {
     /// Wrap [ResetError] as a [PipelineErrorKind::Reset].
@@ -194,42 +155,20 @@ impl ResetError {
 }
 
 /// A decoding error.
-#[derive(derive_more::Display, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum PipelineEncodingError {
     /// The buffer is empty.
-    #[display("Empty buffer")]
+    #[error("Empty buffer")]
     EmptyBuffer,
     /// Deposit decoding error.
-    #[display("Error decoding deposit: {_0}")]
-    DepositError(DepositError),
+    #[error("Error decoding deposit: {0}")]
+    DepositError(#[from] DepositError),
     /// Alloy RLP Encoding Error.
-    #[display("RLP error: {_0}")]
+    #[error("RLP error: {0}")]
     AlloyRlpError(alloy_rlp::Error),
     /// Span Batch Error.
-    #[display("{_0}")]
-    SpanBatchError(SpanBatchError),
-}
-
-impl core::error::Error for PipelineEncodingError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::DepositError(err) => Some(err),
-            Self::SpanBatchError(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-impl From<SpanBatchError> for PipelineEncodingError {
-    fn from(err: SpanBatchError) -> Self {
-        Self::SpanBatchError(err)
-    }
-}
-
-impl From<DepositError> for PipelineEncodingError {
-    fn from(err: DepositError) -> Self {
-        Self::DepositError(err)
-    }
+    #[error("{0}")]
+    SpanBatchError(#[from] SpanBatchError),
 }
 
 #[cfg(test)]

--- a/crates/derive/src/errors/pipeline.rs
+++ b/crates/derive/src/errors/pipeline.rs
@@ -28,13 +28,7 @@ pub enum PipelineErrorKind {
     Critical(#[source] PipelineError),
     /// A reset error.
     #[error("Pipeline reset: {0}")]
-    Reset(#[source] ResetError),
-}
-
-impl From<ResetError> for PipelineErrorKind {
-    fn from(err: ResetError) -> Self {
-        Self::Reset(err)
-    }
+    Reset(#[from] ResetError),
 }
 
 /// An error encountered during the processing.

--- a/crates/derive/src/errors/stages.rs
+++ b/crates/derive/src/errors/stages.rs
@@ -1,13 +1,12 @@
 //! Error types for derivation pipeline stages.
 
 use op_alloy_protocol::MAX_SPAN_BATCH_ELEMENTS;
+use thiserror::Error;
 
 /// A frame decompression error.
-#[derive(derive_more::Display, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum BatchDecompressionError {
     /// The buffer exceeds the [MAX_SPAN_BATCH_ELEMENTS] protocol parameter.
-    #[display("The batch exceeds the maximum number of elements: {max_size}", max_size = MAX_SPAN_BATCH_ELEMENTS)]
+    #[error("The batch exceeds the maximum number of elements: {max_size}", max_size = MAX_SPAN_BATCH_ELEMENTS)]
     BatchTooLarge,
 }
-
-impl core::error::Error for BatchDecompressionError {}

--- a/crates/derive/src/test_utils/attributes_queue.rs
+++ b/crates/derive/src/test_utils/attributes_queue.rs
@@ -12,12 +12,11 @@ use alloy_eips::BlockNumHash;
 use async_trait::async_trait;
 use op_alloy_protocol::{BlockInfo, L2BlockInfo, SingleBatch};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
+use thiserror::Error;
 
 /// An error returned by the [`TestAttributesBuilder`].
-#[derive(derive_more::Display, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum TestAttributesBuilderError {}
-
-impl core::error::Error for TestAttributesBuilderError {}
 
 /// A mock implementation of the [`AttributesBuilder`] for testing.
 #[derive(Debug, Default)]

--- a/crates/derive/src/test_utils/chain_providers.rs
+++ b/crates/derive/src/test_utils/chain_providers.rs
@@ -4,7 +4,6 @@ use crate::{
     errors::{PipelineError, PipelineErrorKind},
     traits::{ChainProvider, L2ChainProvider},
 };
-use thiserror::Error;
 use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_primitives::{map::HashMap, B256};
@@ -12,6 +11,7 @@ use async_trait::async_trait;
 use op_alloy_consensus::OpBlock;
 use op_alloy_genesis::{RollupConfig, SystemConfig};
 use op_alloy_protocol::{BatchValidationProvider, BlockInfo, L2BlockInfo};
+use thiserror::Error;
 
 /// A mock chain provider for testing.
 #[derive(Debug, Clone, Default)]

--- a/crates/derive/src/test_utils/chain_providers.rs
+++ b/crates/derive/src/test_utils/chain_providers.rs
@@ -4,6 +4,7 @@ use crate::{
     errors::{PipelineError, PipelineErrorKind},
     traits::{ChainProvider, L2ChainProvider},
 };
+use thiserror::Error;
 use alloc::{boxed::Box, string::ToString, sync::Arc, vec::Vec};
 use alloy_consensus::{Header, Receipt, TxEnvelope};
 use alloy_primitives::{map::HashMap, B256};
@@ -76,22 +77,22 @@ impl TestChainProvider {
 }
 
 /// An error for the [TestChainProvider] and [TestL2ChainProvider].
-#[derive(Debug, derive_more::Display)]
+#[derive(Error, Debug)]
 pub enum TestProviderError {
     /// The block was not found.
-    #[display("Block not found")]
+    #[error("Block not found")]
     BlockNotFound,
     /// The header was not found.
-    #[display("Header not found")]
+    #[error("Header not found")]
     HeaderNotFound,
     /// The receipts were not found.
-    #[display("Receipts not found")]
+    #[error("Receipts not found")]
     ReceiptsNotFound,
     /// The L2 block was not found.
-    #[display("L2 Block not found")]
+    #[error("L2 Block not found")]
     L2BlockNotFound,
     /// The system config was not found.
-    #[display("System config not found")]
+    #[error("System config not found")]
     SystemConfigNotFound(u64),
 }
 
@@ -100,8 +101,6 @@ impl From<TestProviderError> for PipelineErrorKind {
         PipelineError::Provider(val.to_string()).temp()
     }
 }
-
-impl core::error::Error for TestProviderError {}
 
 #[async_trait]
 impl ChainProvider for TestChainProvider {

--- a/crates/derive/src/test_utils/sys_config_fetcher.rs
+++ b/crates/derive/src/test_utils/sys_config_fetcher.rs
@@ -1,5 +1,6 @@
 //! Implements a mock [L2SystemConfigFetcher] for testing.
 
+use thiserror::Error;
 use crate::{
     errors::{PipelineError, PipelineErrorKind},
     traits::L2ChainProvider,
@@ -31,10 +32,10 @@ impl TestSystemConfigL2Fetcher {
 }
 
 /// An error returned by the [TestSystemConfigL2Fetcher].
-#[derive(derive_more::Display, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum TestSystemConfigL2FetcherError {
     /// The system config was not found.
-    #[display("system config not found: {_0}")]
+    #[error("system config not found: {0}")]
     NotFound(u64),
 }
 
@@ -43,8 +44,6 @@ impl From<TestSystemConfigL2FetcherError> for PipelineErrorKind {
         PipelineError::Provider(val.to_string()).temp()
     }
 }
-
-impl core::error::Error for TestSystemConfigL2FetcherError {}
 
 #[async_trait]
 impl BatchValidationProvider for TestSystemConfigL2Fetcher {

--- a/crates/derive/src/test_utils/sys_config_fetcher.rs
+++ b/crates/derive/src/test_utils/sys_config_fetcher.rs
@@ -1,6 +1,5 @@
 //! Implements a mock [L2SystemConfigFetcher] for testing.
 
-use thiserror::Error;
 use crate::{
     errors::{PipelineError, PipelineErrorKind},
     traits::L2ChainProvider,
@@ -11,6 +10,7 @@ use async_trait::async_trait;
 use op_alloy_consensus::OpBlock;
 use op_alloy_genesis::{RollupConfig, SystemConfig};
 use op_alloy_protocol::{BatchValidationProvider, L2BlockInfo};
+use thiserror::Error;
 
 /// A mock implementation of the `SystemConfigL2Fetcher` for testing.
 #[derive(Debug, Default)]

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -28,5 +28,5 @@ op-alloy-rpc-types-engine.workspace = true
 
 # Misc
 tracing.workspace = true
-derive_more.workspace = true
+thiserror .workspace = true
 async-trait.workspace = true

--- a/crates/driver/src/errors.rs
+++ b/crates/driver/src/errors.rs
@@ -1,8 +1,8 @@
 //! Contains driver-related error types.
 
-use thiserror::Error;
 use kona_derive::errors::PipelineErrorKind;
 use op_alloy_protocol::FromBlockError;
+use thiserror::Error;
 
 /// A [Result] type for the [DriverError].
 pub type DriverResult<T, E> = Result<T, DriverError<E>>;

--- a/crates/driver/src/errors.rs
+++ b/crates/driver/src/errors.rs
@@ -1,6 +1,6 @@
 //! Contains driver-related error types.
 
-use derive_more::derive::Display;
+use thiserror::Error;
 use kona_derive::errors::PipelineErrorKind;
 use op_alloy_protocol::FromBlockError;
 
@@ -8,50 +8,21 @@ use op_alloy_protocol::FromBlockError;
 pub type DriverResult<T, E> = Result<T, DriverError<E>>;
 
 /// Driver error.
-#[derive(Display, Debug)]
+#[derive(Error, Debug)]
 pub enum DriverError<E>
 where
     E: core::error::Error,
 {
     /// Pipeline error.
-    #[display("Pipeline error: {_0}")]
-    Pipeline(PipelineErrorKind),
+    #[error("Pipeline error: {0}")]
+    Pipeline(#[from] PipelineErrorKind),
     /// An error returned by the executor.
-    #[display("Executor error: {_0}")]
+    #[error("Executor error: {0}")]
     Executor(E),
     /// An error returned by the conversion from a block to an [op_alloy_protocol::L2BlockInfo].
-    #[display("From block error: {_0}")]
-    FromBlock(FromBlockError),
+    #[error("From block error: {0}")]
+    FromBlock(#[from] FromBlockError),
     /// Error decoding or encoding RLP.
-    #[display("RLP error: {_0}")]
-    Rlp(alloy_rlp::Error),
-}
-
-impl<E> core::error::Error for DriverError<E> where E: core::error::Error {}
-
-impl<E> From<PipelineErrorKind> for DriverError<E>
-where
-    E: core::error::Error,
-{
-    fn from(val: PipelineErrorKind) -> Self {
-        Self::Pipeline(val)
-    }
-}
-
-impl<E> From<FromBlockError> for DriverError<E>
-where
-    E: core::error::Error,
-{
-    fn from(val: FromBlockError) -> Self {
-        Self::FromBlock(val)
-    }
-}
-
-impl<E> From<alloy_rlp::Error> for DriverError<E>
-where
-    E: core::error::Error,
-{
-    fn from(val: alloy_rlp::Error) -> Self {
-        Self::Rlp(val)
-    }
+    #[error("RLP error: {0}")]
+    Rlp(#[from] alloy_rlp::Error),
 }

--- a/crates/driver/src/errors.rs
+++ b/crates/driver/src/errors.rs
@@ -24,5 +24,5 @@ where
     FromBlock(#[from] FromBlockError),
     /// Error decoding or encoding RLP.
     #[error("RLP error: {0}")]
-    Rlp(#[from] alloy_rlp::Error),
+    Rlp(alloy_rlp::Error),
 }

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -30,7 +30,7 @@ op-alloy-rpc-types-engine.workspace = true
 revm = { workspace = true, features = ["optimism"] }
 
 # General
-derive_more = { workspace = true, features = ["full"] }
+thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/executor/src/errors.rs
+++ b/crates/executor/src/errors.rs
@@ -3,66 +3,46 @@
 use alloc::string::String;
 use kona_mpt::TrieNodeError;
 use revm::primitives::EVMError;
+use thiserror::Error;
 
 /// The error type for the [StatelessL2BlockExecutor].
 ///
 /// [StatelessL2BlockExecutor]: crate::StatelessL2BlockExecutor
-#[derive(derive_more::Display, Debug)]
+#[derive(Error, Debug)]
 pub enum ExecutorError {
     /// Missing gas limit in the payload attributes.
-    #[display("Gas limit not provided in payload attributes")]
+    #[error("Gas limit not provided in payload attributes")]
     MissingGasLimit,
     /// Missing transactions in the payload attributes.
-    #[display("Transactions not provided in payload attributes")]
+    #[error("Transactions not provided in payload attributes")]
     MissingTransactions,
     /// Missing EIP-1559 parameters in execution payload post-Holocene.
-    #[display("Missing EIP-1559 parameters in execution payload post-Holocene")]
+    #[error("Missing EIP-1559 parameters in execution payload post-Holocene")]
     MissingEIP1559Params,
     /// Missing parent beacon block root in the payload attributes.
-    #[display("Parent beacon block root not provided in payload attributes")]
+    #[error("Parent beacon block root not provided in payload attributes")]
     MissingParentBeaconBlockRoot,
     /// Invalid `extraData` field in the block header.
-    #[display("Invalid `extraData` field in the block header")]
+    #[error("Invalid `extraData` field in the block header")]
     InvalidExtraData,
     /// Block gas limit exceeded.
-    #[display("Block gas limit exceeded")]
+    #[error("Block gas limit exceeded")]
     BlockGasLimitExceeded,
     /// Unsupported transaction type.
-    #[display("Unsupported transaction type: {_0}")]
+    #[error("Unsupported transaction type: {0}")]
     UnsupportedTransactionType(u8),
     /// Trie DB error.
-    #[display("Trie error: {_0}")]
-    TrieDBError(TrieDBError),
+    #[error("Trie error: {0}")]
+    TrieDBError(#[from] TrieDBError),
     /// Execution error.
-    #[display("Execution error: {_0}")]
-    ExecutionError(EVMError<TrieDBError>),
+    #[error("Execution error: {0}")]
+    ExecutionError(#[from] EVMError<TrieDBError>),
     /// Signature error.
-    #[display("Signature error: {_0}")]
+    #[error("Signature error: {0}")]
     SignatureError(alloy_primitives::SignatureError),
     /// RLP error.
-    #[display("RLP error: {_0}")]
+    #[error("RLP error: {0}")]
     RLPError(alloy_eips::eip2718::Eip2718Error),
-}
-
-impl From<TrieDBError> for ExecutorError {
-    fn from(err: TrieDBError) -> Self {
-        Self::TrieDBError(err)
-    }
-}
-
-impl From<TrieNodeError> for ExecutorError {
-    fn from(err: TrieNodeError) -> Self {
-        Self::TrieDBError(TrieDBError::TrieNode(err))
-    }
-}
-
-impl core::error::Error for ExecutorError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::TrieDBError(err) => Some(err),
-            _ => None,
-        }
-    }
 }
 
 /// A [Result] type for the [ExecutorError] enum.
@@ -74,33 +54,18 @@ pub type TrieDBResult<T> = Result<T, TrieDBError>;
 /// An error type for [TrieDB] operations.
 ///
 /// [TrieDB]: crate::TrieDB
-#[derive(derive_more::Display, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum TrieDBError {
     /// Trie root node has not been blinded.
-    #[display("Trie root node has not been blinded")]
+    #[error("Trie root node has not been blinded")]
     RootNotBlinded,
     /// Missing account info for bundle account.
-    #[display("Missing account info for bundle account.")]
+    #[error("Missing account info for bundle account.")]
     MissingAccountInfo,
     /// Trie node error.
-    #[display("Trie node error: {_0}")]
-    TrieNode(TrieNodeError),
+    #[error("Trie node error: {0}")]
+    TrieNode(#[from] TrieNodeError),
     /// Trie provider error.
-    #[display("Trie provider error: {_0}")]
+    #[error("Trie provider error: {0}")]
     Provider(String),
-}
-
-impl core::error::Error for TrieDBError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::TrieNode(err) => Some(err),
-            _ => None,
-        }
-    }
-}
-
-impl From<TrieNodeError> for TrieDBError {
-    fn from(err: TrieNodeError) -> Self {
-        Self::TrieNode(err)
-    }
 }

--- a/crates/executor/src/errors.rs
+++ b/crates/executor/src/errors.rs
@@ -36,7 +36,7 @@ pub enum ExecutorError {
     TrieDBError(#[from] TrieDBError),
     /// Execution error.
     #[error("Execution error: {0}")]
-    ExecutionError(#[from] EVMError<TrieDBError>),
+    ExecutionError(EVMError<TrieDBError>),
     /// Signature error.
     #[error("Signature error: {0}")]
     SignatureError(alloy_primitives::SignatureError),

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [dependencies]
 # General
-derive_more = { workspace = true, features = ["full"] }
+thiserror.workspace = true
 serde = { workspace = true, optional = true, features = ["derive", "alloc"] }
 
 # Revm + Alloy

--- a/crates/mpt/src/errors.rs
+++ b/crates/mpt/src/errors.rs
@@ -1,6 +1,7 @@
 //! Errors for the `kona-derive` crate.
 
 use alloc::string::String;
+use thiserror::Error;
 
 /// A [Result] type alias where the error is [TrieNodeError].
 pub type TrieNodeResult<T> = Result<T, TrieNodeError>;
@@ -8,23 +9,21 @@ pub type TrieNodeResult<T> = Result<T, TrieNodeError>;
 /// An error type for [TrieNode] operations.
 ///
 /// [TrieNode]: crate::TrieNode
-#[derive(Debug, derive_more::Display, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum TrieNodeError {
     /// Invalid trie node type encountered.
-    #[display("Invalid trie node type encountered")]
+    #[error("Invalid trie node type encountered")]
     InvalidNodeType,
     /// Failed to decode trie node.
-    #[display("Failed to decode trie node: {_0}")]
+    #[error("Failed to decode trie node: {0}")]
     RLPError(alloy_rlp::Error),
     /// Key does not exist in trie.
-    #[display("Key does not exist in trie. Encountered {_0} node.")]
-    KeyNotFound(String),
+    #[error("Key does not exist in trie.")]
+    KeyNotFound,
     /// Trie node is not a leaf node.
-    #[display("Trie provider error: {_0}")]
+    #[error("Trie provider error: {0}")]
     Provider(String),
 }
-
-impl core::error::Error for TrieNodeError {}
 
 /// A [Result] type alias where the error is [OrderedListWalkerError].
 pub type OrderedListWalkerResult<T> = Result<T, OrderedListWalkerError>;
@@ -32,29 +31,14 @@ pub type OrderedListWalkerResult<T> = Result<T, OrderedListWalkerError>;
 /// An error type for [OrderedListWalker] operations.
 ///
 /// [OrderedListWalker]: crate::OrderedListWalker
-#[derive(derive_more::Display, Debug, PartialEq, Eq)]
+#[derive(Error, Debug, PartialEq, Eq)]
 pub enum OrderedListWalkerError {
     /// Iterator has already been hydrated, and cannot be re-hydrated until it is exhausted.
-    #[display(
+    #[error(
         "Iterator has already been hydrated, and cannot be re-hydrated until it is exhausted"
     )]
     AlreadyHydrated,
     /// Trie node error.
-    #[display("{_0}")]
-    TrieNode(TrieNodeError),
-}
-
-impl From<TrieNodeError> for OrderedListWalkerError {
-    fn from(err: TrieNodeError) -> Self {
-        Self::TrieNode(err)
-    }
-}
-
-impl core::error::Error for OrderedListWalkerError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::TrieNode(err) => Some(err),
-            _ => None,
-        }
-    }
+    #[error("{0}")]
+    TrieNode(#[from] TrieNodeError),
 }

--- a/crates/mpt/src/errors.rs
+++ b/crates/mpt/src/errors.rs
@@ -34,9 +34,7 @@ pub type OrderedListWalkerResult<T> = Result<T, OrderedListWalkerError>;
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum OrderedListWalkerError {
     /// Iterator has already been hydrated, and cannot be re-hydrated until it is exhausted.
-    #[error(
-        "Iterator has already been hydrated, and cannot be re-hydrated until it is exhausted"
-    )]
+    #[error("Iterator has already been hydrated, and cannot be re-hydrated until it is exhausted")]
     AlreadyHydrated,
     /// Trie node error.
     #[error("{0}")]

--- a/crates/preimage/Cargo.toml
+++ b/crates/preimage/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 # General
 tracing.workspace = true
-derive_more = { workspace = true, features = ["full"] }
+thiserror.workspace = true
 async-trait.workspace = true
 alloy-primitives.workspace = true
 

--- a/crates/preimage/src/errors.rs
+++ b/crates/preimage/src/errors.rs
@@ -2,60 +2,31 @@
 
 use alloc::string::String;
 use kona_common::errors::IOError;
+use thiserror::Error;
 
 /// A [PreimageOracleError] is an enum that differentiates pipe-related errors from other errors
 /// in the [PreimageOracleServer] and [HintReaderServer] implementations.
 ///
 /// [PreimageOracleServer]: crate::PreimageOracleServer
 /// [HintReaderServer]: crate::HintReaderServer
-#[derive(derive_more::Display, Debug)]
+#[derive(Error, Debug)]
 pub enum PreimageOracleError {
     /// The pipe has been broken.
-    #[display("{_0}")]
-    IOError(IOError),
+    #[error(transparent)]
+    IOError(#[from] IOError),
     /// The preimage key is invalid.
-    #[display("{_0}")]
-    InvalidPreimageKey(InvalidPreimageKeyType),
+    #[error("Invalid preimage key.")]
+    InvalidPreimageKey,
     /// Key not found.
-    #[display("Key not found.")]
+    #[error("Key not found.")]
     KeyNotFound,
     /// Buffer length mismatch.
-    #[display("Buffer length mismatch. Expected {_0}, got {_1}.")]
+    #[error("Buffer length mismatch. Expected {0}, got {1}.")]
     BufferLengthMismatch(usize, usize),
     /// Other errors.
-    #[display("Error in preimage server: {_0}")]
+    #[error("Error in preimage server: {0}")]
     Other(String),
-}
-
-impl From<IOError> for PreimageOracleError {
-    fn from(err: IOError) -> Self {
-        Self::IOError(err)
-    }
-}
-
-impl From<InvalidPreimageKeyType> for PreimageOracleError {
-    fn from(err: InvalidPreimageKeyType) -> Self {
-        Self::InvalidPreimageKey(err)
-    }
-}
-
-impl core::error::Error for PreimageOracleError {
-    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
-        match self {
-            Self::IOError(err) => Some(err),
-            _ => None,
-        }
-    }
 }
 
 /// A [Result] type for the [PreimageOracleError] enum.
 pub type PreimageOracleResult<T> = Result<T, PreimageOracleError>;
-
-/// Invalid [PreimageKeyType] error.
-///
-/// [PreimageKeyType]: crate::key::PreimageKeyType
-#[derive(derive_more::Display, Debug)]
-#[display("Invalid preimage key type")]
-pub struct InvalidPreimageKeyType;
-
-impl core::error::Error for InvalidPreimageKeyType {}

--- a/crates/preimage/src/key.rs
+++ b/crates/preimage/src/key.rs
@@ -1,12 +1,13 @@
 //! Contains the [PreimageKey] type, which is used to identify preimages that may be fetched from
 //! the preimage oracle.
 
-use crate::errors::InvalidPreimageKeyType;
 use alloy_primitives::{B256, U256};
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 #[cfg(feature = "serde")]
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
+
+use crate::errors::PreimageOracleError;
 
 /// <https://specs.optimism.io/experimental/fault-proof/index.html#pre-image-key-types>
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
@@ -37,7 +38,7 @@ pub enum PreimageKeyType {
 }
 
 impl TryFrom<u8> for PreimageKeyType {
-    type Error = InvalidPreimageKeyType;
+    type Error = PreimageOracleError;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         let key_type = match value {
@@ -47,7 +48,7 @@ impl TryFrom<u8> for PreimageKeyType {
             4 => Self::Sha256,
             5 => Self::Blob,
             6 => Self::Precompile,
-            _ => return Err(InvalidPreimageKeyType),
+            _ => return Err(PreimageOracleError::InvalidPreimageKey),
         };
         Ok(key_type)
     }
@@ -114,7 +115,7 @@ impl From<PreimageKey> for B256 {
 }
 
 impl TryFrom<[u8; 32]> for PreimageKey {
-    type Error = InvalidPreimageKeyType;
+    type Error = PreimageOracleError;
 
     fn try_from(value: [u8; 32]) -> Result<Self, Self::Error> {
         let key_type = PreimageKeyType::try_from(value[0])?;


### PR DESCRIPTION
## Overview

Migrates all crates back to `thiserror`, now that `>=v2.0.0` has support for `no_std` with `default-features = false`.

closes #806