### PR TITLE
feat(mpt): Extend `TrieProvider` in `kona-executor`

### DIFF
--- a/bin/client/src/executor.rs
+++ b/bin/client/src/executor.rs
@@ -4,8 +4,8 @@ use alloc::sync::Arc;
 use alloy_consensus::{Header, Sealed};
 use alloy_primitives::B256;
 use kona_driver::{Executor, ExecutorConstructor};
-use kona_executor::{KonaHandleRegister, StatelessL2BlockExecutor};
-use kona_mpt::{TrieHinter, TrieProvider};
+use kona_executor::{KonaHandleRegister, StatelessL2BlockExecutor, TrieDBProvider};
+use kona_mpt::TrieHinter;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 
@@ -13,12 +13,12 @@ use op_alloy_rpc_types_engine::OpPayloadAttributes;
 #[derive(Debug)]
 pub struct KonaExecutor<'a, P, H>(StatelessL2BlockExecutor<'a, P, H>)
 where
-    P: TrieProvider + Send + Sync + Clone,
+    P: TrieDBProvider + Send + Sync + Clone,
     H: TrieHinter + Send + Sync + Clone;
 
 impl<'a, P, H> KonaExecutor<'a, P, H>
 where
-    P: TrieProvider + Send + Sync + Clone,
+    P: TrieDBProvider + Send + Sync + Clone,
     H: TrieHinter + Send + Sync + Clone,
 {
     /// Creates a new executor.
@@ -29,7 +29,7 @@ where
 
 impl<P, H> Executor for KonaExecutor<'_, P, H>
 where
-    P: TrieProvider + Send + Sync + Clone,
+    P: TrieDBProvider + Send + Sync + Clone,
     H: TrieHinter + Send + Sync + Clone,
 {
     type Error = kona_executor::ExecutorError;
@@ -49,7 +49,7 @@ where
 #[derive(Debug)]
 pub struct KonaExecutorConstructor<'a, P, H>
 where
-    P: TrieProvider + Send + Sync + Clone,
+    P: TrieDBProvider + Send + Sync + Clone,
     H: TrieHinter + Send + Sync + Clone,
 {
     /// The rollup config for the executor.
@@ -64,7 +64,7 @@ where
 
 impl<'a, P, H> KonaExecutorConstructor<'a, P, H>
 where
-    P: TrieProvider + Send + Sync + Clone,
+    P: TrieDBProvider + Send + Sync + Clone,
     H: TrieHinter + Send + Sync + Clone,
 {
     /// Creates a new executor constructor.
@@ -80,7 +80,7 @@ where
 
 impl<'a, P, H> ExecutorConstructor<KonaExecutor<'a, P, H>> for KonaExecutorConstructor<'a, P, H>
 where
-    P: TrieProvider + Send + Sync + Clone,
+    P: TrieDBProvider + Send + Sync + Clone,
     H: TrieHinter + Send + Sync + Clone,
 {
     /// Constructs the executor.

--- a/bin/client/src/fault/handler/mod.rs
+++ b/bin/client/src/fault/handler/mod.rs
@@ -3,8 +3,8 @@
 //! [KonaHandleRegister]: kona_executor::KonaHandleRegister
 
 use alloc::sync::Arc;
-use kona_executor::TrieDB;
-use kona_mpt::{TrieHinter, TrieProvider};
+use kona_executor::{TrieDB, TrieDBProvider};
+use kona_mpt::TrieHinter;
 use revm::{
     handler::register::EvmHandler,
     primitives::{spec_to_generic, SpecId},
@@ -21,7 +21,7 @@ mod kzg_point_eval;
 pub(crate) fn fpvm_handle_register<F, H>(
     handler: &mut EvmHandler<'_, (), &mut State<&mut TrieDB<F, H>>>,
 ) where
-    F: TrieProvider,
+    F: TrieDBProvider,
     H: TrieHinter,
 {
     let spec_id = handler.cfg.spec_id;

--- a/bin/client/src/l1/chain_provider.rs
+++ b/bin/client/src/l1/chain_provider.rs
@@ -4,7 +4,7 @@ use crate::{errors::OracleProviderError, BootInfo, HintType};
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
 use alloy_consensus::{Header, Receipt, ReceiptEnvelope, TxEnvelope};
 use alloy_eips::eip2718::Decodable2718;
-use alloy_primitives::{Bytes, B256};
+use alloy_primitives::B256;
 use alloy_rlp::Decodable;
 use async_trait::async_trait;
 use kona_derive::traits::ChainProvider;
@@ -152,13 +152,5 @@ impl<T: CommsClient> TrieProvider for OracleL1ChainProvider<T> {
             )
             .map_err(OracleProviderError::Rlp)
         })
-    }
-
-    fn bytecode_by_hash(&self, _: B256) -> Result<Bytes, Self::Error> {
-        unimplemented!("TrieProvider::bytecode_by_hash unimplemented for OracleL1ChainProvider")
-    }
-
-    fn header_by_hash(&self, _: B256) -> Result<Header, Self::Error> {
-        unimplemented!("TrieProvider::header_by_hash unimplemented for OracleL1ChainProvider")
     }
 }

--- a/bin/client/src/l2/chain_provider.rs
+++ b/bin/client/src/l2/chain_provider.rs
@@ -8,6 +8,7 @@ use alloy_primitives::{Address, Bytes, B256};
 use alloy_rlp::Decodable;
 use async_trait::async_trait;
 use kona_derive::traits::L2ChainProvider;
+use kona_executor::TrieDBProvider;
 use kona_mpt::{OrderedListWalker, TrieHinter, TrieNode, TrieProvider};
 use kona_preimage::{CommsClient, PreimageKey, PreimageKeyType};
 use op_alloy_consensus::{OpBlock, OpTxEnvelope};
@@ -159,7 +160,9 @@ impl<T: CommsClient> TrieProvider for OracleL2ChainProvider<T> {
             .map_err(OracleProviderError::Rlp)
         })
     }
+}
 
+impl<T: CommsClient> TrieDBProvider for OracleL2ChainProvider<T> {
     fn bytecode_by_hash(&self, hash: B256) -> Result<Bytes, OracleProviderError> {
         // Fetch the bytecode preimage from the caching oracle.
         kona_common::block_on(async move {

--- a/bin/client/src/sync.rs
+++ b/bin/client/src/sync.rs
@@ -9,7 +9,7 @@ use alloy_consensus::Sealed;
 use core::fmt::Debug;
 use kona_derive::traits::ChainProvider;
 use kona_driver::{PipelineCursor, TipCursor};
-use kona_mpt::TrieProvider;
+use kona_executor::TrieDBProvider;
 use kona_preimage::{CommsClient, PreimageKey, PreimageKeyType};
 use op_alloy_protocol::BatchValidationProvider;
 

--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -15,7 +15,7 @@ cfg_if! {
         pub(crate) type ClientIO = crate::zkvm::io::ZkvmIO;
     } else {
         #[doc = "Concrete implementation of the [BasicKernelInterface] trait for the `native` target architecture."]
-        pub(crate) type ClientIO = native_io::NativeIO<'static>;
+        pub(crate) type ClientIO = native_io::NativeIO;
     }
 }
 

--- a/crates/common/src/io.rs
+++ b/crates/common/src/io.rs
@@ -15,7 +15,7 @@ cfg_if! {
         pub(crate) type ClientIO = crate::zkvm::io::ZkvmIO;
     } else {
         #[doc = "Concrete implementation of the [BasicKernelInterface] trait for the `native` target architecture."]
-        pub(crate) type ClientIO = native_io::NativeIO;
+        pub(crate) type ClientIO = native_io::NativeIO<'static>;
     }
 }
 

--- a/crates/executor/benches/execution.rs
+++ b/crates/executor/benches/execution.rs
@@ -7,7 +7,7 @@ use alloy_rlp::Decodable;
 use alloy_rpc_types_engine::PayloadAttributes;
 use anyhow::{anyhow, Result};
 use criterion::{criterion_group, criterion_main, Bencher, Criterion};
-use kona_executor::StatelessL2BlockExecutor;
+use kona_executor::{StatelessL2BlockExecutor, TrieDBProvider};
 use kona_mpt::{NoopTrieHinter, TrieNode, TrieProvider};
 use op_alloy_genesis::{RollupConfig, OP_MAINNET_BASE_FEE_PARAMS};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
@@ -48,7 +48,9 @@ impl TrieProvider for TestdataTrieProvider {
         )
         .map_err(Into::into)
     }
+}
 
+impl TrieDBProvider for TestdataTrieProvider {
     fn bytecode_by_hash(&self, code_hash: B256) -> Result<Bytes> {
         self.preimages
             .get(&code_hash)

--- a/crates/executor/src/db/mod.rs
+++ b/crates/executor/src/db/mod.rs
@@ -6,7 +6,7 @@ use alloc::{string::ToString, vec::Vec};
 use alloy_consensus::{Header, Sealed, EMPTY_ROOT_HASH};
 use alloy_primitives::{keccak256, Address, B256, U256};
 use alloy_rlp::{Decodable, Encodable};
-use kona_mpt::{Nibbles, TrieHinter, TrieNode, TrieNodeError, TrieProvider};
+use kona_mpt::{Nibbles, TrieHinter, TrieNode, TrieNodeError};
 use revm::{
     db::{states::StorageSlot, BundleState},
     primitives::{AccountInfo, Bytecode, HashMap, BLOCK_HASH_HISTORY},
@@ -16,6 +16,9 @@ use tracing::debug;
 
 mod account;
 pub use account::TrieAccount;
+
+mod traits;
+pub use traits::{NoopTrieDBProvider, TrieDBProvider};
 
 /// A Trie DB that caches open state in-memory.
 ///
@@ -77,7 +80,7 @@ pub use account::TrieAccount;
 #[derive(Debug, Clone)]
 pub struct TrieDB<F, H>
 where
-    F: TrieProvider,
+    F: TrieDBProvider,
     H: TrieHinter,
 {
     /// The [TrieNode] representation of the root node.
@@ -86,7 +89,7 @@ where
     storage_roots: HashMap<Address, TrieNode>,
     /// The parent block hash of the current block.
     parent_block_header: Sealed<Header>,
-    /// The [TrieProvider]
+    /// The [TrieDBProvider]
     fetcher: F,
     /// The [TrieHinter]
     hinter: H,
@@ -94,7 +97,7 @@ where
 
 impl<F, H> TrieDB<F, H>
 where
-    F: TrieProvider,
+    F: TrieDBProvider,
     H: TrieHinter,
 {
     /// Creates a new [TrieDB] with the given root node.
@@ -294,7 +297,7 @@ where
 
 impl<F, H> Database for TrieDB<F, H>
 where
-    F: TrieProvider,
+    F: TrieDBProvider,
     H: TrieHinter,
 {
     type Error = TrieDBError;
@@ -364,8 +367,8 @@ where
         let mut header = self.parent_block_header.inner().clone();
 
         // Check if the block number is in range. If not, we can fail early.
-        if block_number > header.number ||
-            header.number.saturating_sub(block_number) > BLOCK_HASH_HISTORY
+        if block_number > header.number
+            || header.number.saturating_sub(block_number) > BLOCK_HASH_HISTORY
         {
             return Ok(B256::default());
         }
@@ -387,13 +390,13 @@ mod tests {
     use super::*;
     use alloy_consensus::Sealable;
     use alloy_primitives::b256;
-    use kona_mpt::{NoopTrieHinter, NoopTrieProvider};
+    use kona_mpt::NoopTrieHinter;
 
-    fn new_test_db() -> TrieDB<NoopTrieProvider, NoopTrieHinter> {
+    fn new_test_db() -> TrieDB<NoopTrieDBProvider, NoopTrieHinter> {
         TrieDB::new(
             B256::default(),
             Header::default().seal_slow(),
-            NoopTrieProvider,
+            NoopTrieDBProvider,
             NoopTrieHinter,
         )
     }

--- a/crates/executor/src/db/mod.rs
+++ b/crates/executor/src/db/mod.rs
@@ -50,7 +50,7 @@ pub use traits::{NoopTrieDBProvider, TrieDBProvider};
 /// use alloy_consensus::{Header, Sealable};
 /// use alloy_primitives::{Bytes, B256};
 /// use anyhow::Result;
-/// use kona_executor::{TrieDB, NoopTrieDBProvider};
+/// use kona_executor::{NoopTrieDBProvider, TrieDB};
 /// use kona_mpt::NoopTrieHinter;
 /// use revm::{db::states::bundle_state::BundleRetention, EvmBuilder, StateBuilder};
 ///
@@ -367,8 +367,8 @@ where
         let mut header = self.parent_block_header.inner().clone();
 
         // Check if the block number is in range. If not, we can fail early.
-        if block_number > header.number
-            || header.number.saturating_sub(block_number) > BLOCK_HASH_HISTORY
+        if block_number > header.number ||
+            header.number.saturating_sub(block_number) > BLOCK_HASH_HISTORY
         {
             return Ok(B256::default());
         }

--- a/crates/executor/src/db/mod.rs
+++ b/crates/executor/src/db/mod.rs
@@ -50,8 +50,8 @@ pub use traits::{NoopTrieDBProvider, TrieDBProvider};
 /// use alloy_consensus::{Header, Sealable};
 /// use alloy_primitives::{Bytes, B256};
 /// use anyhow::Result;
-/// use kona_executor::TrieDB;
-/// use kona_mpt::{NoopTrieHinter, NoopTrieProvider};
+/// use kona_executor::{TrieDB, NoopTrieDBProvider};
+/// use kona_mpt::NoopTrieHinter;
 /// use revm::{db::states::bundle_state::BundleRetention, EvmBuilder, StateBuilder};
 ///
 /// let mock_starting_root = B256::default();
@@ -60,7 +60,7 @@ pub use traits::{NoopTrieDBProvider, TrieDBProvider};
 /// let trie_db = TrieDB::new(
 ///     mock_starting_root,
 ///     mock_parent_block_header.seal_slow(),
-///     NoopTrieProvider,
+///     NoopTrieDBProvider,
 ///     NoopTrieHinter,
 /// );
 /// let mut state = StateBuilder::new_with_database(trie_db).with_bundle_update().build();

--- a/crates/executor/src/db/traits.rs
+++ b/crates/executor/src/db/traits.rs
@@ -1,0 +1,57 @@
+//! Contains the [TrieDBProvider] trait for fetching EVM bytecode hash preimages as well as [Header]
+//! preimages.
+
+use alloc::string::String;
+use alloy_consensus::Header;
+use alloy_primitives::{Bytes, B256};
+use kona_mpt::{TrieNode, TrieProvider};
+
+/// The [TrieDBProvider] trait defines the synchronous interface for fetching EVM bytecode hash preimages
+/// as well as [Header] preimages.
+pub trait TrieDBProvider: TrieProvider {
+    /// Fetches the preimage of the bytecode hash provided.
+    ///
+    /// ## Takes
+    /// - `hash`: The hash of the bytecode.
+    ///
+    /// ## Returns
+    /// - Ok(Bytes): The bytecode of the contract.
+    /// - Err(anyhow::Error): If the bytecode hash could not be fetched.
+    ///
+    /// [TrieDB]: crate::TrieDB
+    fn bytecode_by_hash(&self, code_hash: B256) -> Result<Bytes, Self::Error>;
+
+    /// Fetches the preimage of [Header] hash provided.
+    ///
+    /// ## Takes
+    /// - `hash`: The hash of the RLP-encoded [Header].
+    ///
+    /// ## Returns
+    /// - Ok(Bytes): The [Header].
+    /// - Err(anyhow::Error): If the [Header] could not be fetched.
+    ///
+    /// [TrieDB]: crate::TrieDB
+    fn header_by_hash(&self, hash: B256) -> Result<Header, Self::Error>;
+}
+
+/// The default, no-op implementation of the [TrieDBProvider] trait, used for testing.
+#[derive(Debug, Clone, Copy)]
+pub struct NoopTrieDBProvider;
+
+impl TrieProvider for NoopTrieDBProvider {
+    type Error = String;
+
+    fn trie_node_by_hash(&self, _key: B256) -> Result<TrieNode, Self::Error> {
+        Ok(TrieNode::Empty)
+    }
+}
+
+impl TrieDBProvider for NoopTrieDBProvider {
+    fn bytecode_by_hash(&self, _code_hash: B256) -> Result<Bytes, Self::Error> {
+        Ok(Bytes::default())
+    }
+
+    fn header_by_hash(&self, _hash: B256) -> Result<Header, Self::Error> {
+        Ok(Header::default())
+    }
+}

--- a/crates/executor/src/db/traits.rs
+++ b/crates/executor/src/db/traits.rs
@@ -6,8 +6,8 @@ use alloy_consensus::Header;
 use alloy_primitives::{Bytes, B256};
 use kona_mpt::{TrieNode, TrieProvider};
 
-/// The [TrieDBProvider] trait defines the synchronous interface for fetching EVM bytecode hash preimages
-/// as well as [Header] preimages.
+/// The [TrieDBProvider] trait defines the synchronous interface for fetching EVM bytecode hash
+/// preimages as well as [Header] preimages.
 pub trait TrieDBProvider: TrieProvider {
     /// Fetches the preimage of the bytecode hash provided.
     ///

--- a/crates/executor/src/executor/builder.rs
+++ b/crates/executor/src/executor/builder.rs
@@ -1,9 +1,9 @@
 //! Contains the builder pattern for the [StatelessL2BlockExecutor].
 
 use super::StatelessL2BlockExecutor;
-use crate::db::TrieDB;
+use crate::db::{TrieDB, TrieDBProvider};
 use alloy_consensus::{Header, Sealable, Sealed};
-use kona_mpt::{TrieHinter, TrieProvider};
+use kona_mpt::TrieHinter;
 use op_alloy_genesis::RollupConfig;
 use revm::{db::State, handler::register::EvmHandler};
 
@@ -15,7 +15,7 @@ pub type KonaHandleRegister<F, H> =
 #[derive(Debug)]
 pub struct StatelessL2BlockExecutorBuilder<'a, F, H>
 where
-    F: TrieProvider,
+    F: TrieDBProvider,
     H: TrieHinter,
 {
     /// The [RollupConfig].
@@ -32,7 +32,7 @@ where
 
 impl<'a, F, H> StatelessL2BlockExecutorBuilder<'a, F, H>
 where
-    F: TrieProvider,
+    F: TrieDBProvider,
     H: TrieHinter,
 {
     /// Instantiate a new builder with the given [RollupConfig].
@@ -72,7 +72,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kona_mpt::{NoopTrieHinter, NoopTrieProvider};
+    use crate::NoopTrieDBProvider;
+    use kona_mpt::NoopTrieHinter;
 
     #[test]
     fn test_build_full() {
@@ -81,13 +82,13 @@ mod tests {
 
         fn test_handler_register<F, H>(_: &mut EvmHandler<'_, (), &mut State<&mut TrieDB<F, H>>>)
         where
-            F: TrieProvider,
+            F: TrieDBProvider,
             H: TrieHinter,
         {
         }
 
         let executor =
-            StatelessL2BlockExecutorBuilder::new(&config, NoopTrieProvider, NoopTrieHinter)
+            StatelessL2BlockExecutorBuilder::new(&config, NoopTrieDBProvider, NoopTrieHinter)
                 .with_handle_register(test_handler_register)
                 .build();
 

--- a/crates/executor/src/executor/builder.rs
+++ b/crates/executor/src/executor/builder.rs
@@ -20,7 +20,7 @@ where
 {
     /// The [RollupConfig].
     config: &'a RollupConfig,
-    /// The [TrieProvider] to fetch the state trie preimages.
+    /// The [TrieDBProvider] to fetch the state trie preimages.
     provider: F,
     /// The [TrieHinter] to hint the state trie preimages.
     hinter: H,

--- a/crates/executor/src/executor/env.rs
+++ b/crates/executor/src/executor/env.rs
@@ -1,11 +1,11 @@
 //! Environment preparation for the executor.
 
 use super::{util::decode_holocene_eip_1559_params, StatelessL2BlockExecutor};
-use crate::{constants::FEE_RECIPIENT, ExecutorError, ExecutorResult};
+use crate::{constants::FEE_RECIPIENT, ExecutorError, ExecutorResult, TrieDBProvider};
 use alloy_consensus::Header;
 use alloy_eips::eip1559::BaseFeeParams;
 use alloy_primitives::{TxKind, U256};
-use kona_mpt::{TrieHinter, TrieProvider};
+use kona_mpt::TrieHinter;
 use op_alloy_consensus::OpTxEnvelope;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
@@ -16,7 +16,7 @@ use revm::primitives::{
 
 impl<P, H> StatelessL2BlockExecutor<'_, P, H>
 where
-    P: TrieProvider,
+    P: TrieDBProvider,
     H: TrieHinter,
 {
     /// Returns the active [SpecId] for the executor.

--- a/crates/executor/src/executor/mod.rs
+++ b/crates/executor/src/executor/mod.rs
@@ -160,8 +160,8 @@ where
             // The sum of the transaction’s gas limit, Tg, and the gas utilized in this block prior,
             // must be no greater than the block’s gasLimit.
             let block_available_gas = (gas_limit - cumulative_gas_used) as u128;
-            if (transaction.gas_limit() as u128) > block_available_gas
-                && (is_regolith || !transaction.is_system_transaction())
+            if (transaction.gas_limit() as u128) > block_available_gas &&
+                (is_regolith || !transaction.is_system_transaction())
             {
                 return Err(ExecutorError::BlockGasLimitExceeded);
             }

--- a/crates/executor/src/executor/mod.rs
+++ b/crates/executor/src/executor/mod.rs
@@ -5,13 +5,13 @@ use crate::{
     db::TrieDB,
     errors::TrieDBError,
     syscalls::{ensure_create2_deployer_canyon, pre_block_beacon_root_contract_call},
-    ExecutorError, ExecutorResult,
+    ExecutorError, ExecutorResult, TrieDBProvider,
 };
 use alloc::vec::Vec;
 use alloy_consensus::{Header, Sealable, Transaction, EMPTY_OMMER_ROOT_HASH, EMPTY_ROOT_HASH};
 use alloy_eips::eip2718::{Decodable2718, Encodable2718};
 use alloy_primitives::{keccak256, logs_bloom, Bytes, Log, B256, U256};
-use kona_mpt::{ordered_trie_with_encoder, TrieHinter, TrieProvider};
+use kona_mpt::{ordered_trie_with_encoder, TrieHinter};
 use op_alloy_consensus::{OpReceiptEnvelope, OpTxEnvelope};
 use op_alloy_genesis::RollupConfig;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
@@ -35,7 +35,7 @@ use util::encode_holocene_eip_1559_params;
 #[derive(Debug)]
 pub struct StatelessL2BlockExecutor<'a, F, H>
 where
-    F: TrieProvider,
+    F: TrieDBProvider,
     H: TrieHinter,
 {
     /// The [RollupConfig].
@@ -48,7 +48,7 @@ where
 
 impl<'a, F, H> StatelessL2BlockExecutor<'a, F, H>
 where
-    F: TrieProvider,
+    F: TrieDBProvider,
     H: TrieHinter,
 {
     /// Constructs a new [StatelessL2BlockExecutorBuilder] with the given [RollupConfig].
@@ -160,8 +160,8 @@ where
             // The sum of the transaction’s gas limit, Tg, and the gas utilized in this block prior,
             // must be no greater than the block’s gasLimit.
             let block_available_gas = (gas_limit - cumulative_gas_used) as u128;
-            if (transaction.gas_limit() as u128) > block_available_gas &&
-                (is_regolith || !transaction.is_system_transaction())
+            if (transaction.gas_limit() as u128) > block_available_gas
+                && (is_regolith || !transaction.is_system_transaction())
             {
                 return Err(ExecutorError::BlockGasLimitExceeded);
             }
@@ -449,14 +449,14 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::constants::FEE_RECIPIENT;
+    use crate::{constants::FEE_RECIPIENT, db::TrieDBProvider};
 
     use super::*;
     use alloy_primitives::{b256, hex};
     use alloy_rlp::Decodable;
     use alloy_rpc_types_engine::PayloadAttributes;
     use anyhow::{anyhow, Result};
-    use kona_mpt::{NoopTrieHinter, TrieNode};
+    use kona_mpt::{NoopTrieHinter, TrieNode, TrieProvider};
     use op_alloy_genesis::OP_MAINNET_BASE_FEE_PARAMS;
     use serde::Deserialize;
     use std::collections::HashMap;
@@ -494,7 +494,9 @@ mod test {
             )
             .map_err(Into::into)
         }
+    }
 
+    impl TrieDBProvider for TestdataTrieProvider {
         fn bytecode_by_hash(&self, code_hash: B256) -> Result<Bytes> {
             self.preimages
                 .get(&code_hash)

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -16,7 +16,7 @@ mod executor;
 pub use executor::{KonaHandleRegister, StatelessL2BlockExecutor, StatelessL2BlockExecutorBuilder};
 
 mod db;
-pub use db::{TrieAccount, TrieDB};
+pub use db::{TrieAccount, TrieDB, TrieDBProvider, NoopTrieDBProvider};
 
 mod constants;
 mod syscalls;

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -16,7 +16,7 @@ mod executor;
 pub use executor::{KonaHandleRegister, StatelessL2BlockExecutor, StatelessL2BlockExecutorBuilder};
 
 mod db;
-pub use db::{TrieAccount, TrieDB, TrieDBProvider, NoopTrieDBProvider};
+pub use db::{NoopTrieDBProvider, TrieAccount, TrieDB, TrieDBProvider};
 
 mod constants;
 mod syscalls;

--- a/crates/executor/src/syscalls/canyon.rs
+++ b/crates/executor/src/syscalls/canyon.rs
@@ -33,8 +33,8 @@ where
 {
     // If the canyon hardfork is active at the current timestamp, and it was not active at the
     // previous block timestamp, then we need to force-deploy the create2 deployer contract.
-    if config.is_canyon_active(timestamp)
-        && !config.is_canyon_active(db.database.parent_block_header().timestamp)
+    if config.is_canyon_active(timestamp) &&
+        !config.is_canyon_active(db.database.parent_block_header().timestamp)
     {
         // Load the create2 deployer account from the cache.
         let acc = db.load_cache_account(CREATE_2_DEPLOYER_ADDR)?;

--- a/crates/executor/src/syscalls/canyon.rs
+++ b/crates/executor/src/syscalls/canyon.rs
@@ -1,8 +1,8 @@
 //! Contains logic specific to Canyon hardfork activation.
 
-use crate::{db::TrieDB, errors::ExecutorResult};
+use crate::{db::TrieDB, errors::ExecutorResult, TrieDBProvider};
 use alloy_primitives::{address, b256, hex, Address, Bytes, B256};
-use kona_mpt::{TrieHinter, TrieProvider};
+use kona_mpt::TrieHinter;
 use op_alloy_genesis::RollupConfig;
 use revm::{
     primitives::{Account, Bytecode, HashMap},
@@ -28,13 +28,13 @@ pub(crate) fn ensure_create2_deployer_canyon<F, H>(
     timestamp: u64,
 ) -> ExecutorResult<()>
 where
-    F: TrieProvider,
+    F: TrieDBProvider,
     H: TrieHinter,
 {
     // If the canyon hardfork is active at the current timestamp, and it was not active at the
     // previous block timestamp, then we need to force-deploy the create2 deployer contract.
-    if config.is_canyon_active(timestamp) &&
-        !config.is_canyon_active(db.database.parent_block_header().timestamp)
+    if config.is_canyon_active(timestamp)
+        && !config.is_canyon_active(db.database.parent_block_header().timestamp)
     {
         // Load the create2 deployer account from the cache.
         let acc = db.load_cache_account(CREATE_2_DEPLOYER_ADDR)?;

--- a/crates/executor/src/syscalls/eip4788.rs
+++ b/crates/executor/src/syscalls/eip4788.rs
@@ -3,11 +3,12 @@
 use crate::{
     db::TrieDB,
     errors::{ExecutorError, ExecutorResult},
+    TrieDBProvider,
 };
 use alloc::{boxed::Box, vec::Vec};
 use alloy_eips::eip4788::BEACON_ROOTS_ADDRESS;
 use alloy_primitives::{Address, Bytes, B256, U256};
-use kona_mpt::{TrieHinter, TrieProvider};
+use kona_mpt::TrieHinter;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 use revm::{
@@ -28,7 +29,7 @@ pub(crate) fn pre_block_beacon_root_contract_call<F, H>(
     payload: &OpPayloadAttributes,
 ) -> ExecutorResult<()>
 where
-    F: TrieProvider,
+    F: TrieDBProvider,
     H: TrieHinter,
 {
     // apply pre-block EIP-4788 contract call
@@ -60,7 +61,7 @@ fn apply_beacon_root_contract_call<F, H>(
     evm: &mut Evm<'_, (), &mut State<&mut TrieDB<F, H>>>,
 ) -> ExecutorResult<()>
 where
-    F: TrieProvider,
+    F: TrieDBProvider,
     H: TrieHinter,
 {
     if !config.is_ecotone_active(timestamp) {

--- a/crates/mpt/Cargo.toml
+++ b/crates/mpt/Cargo.toml
@@ -19,7 +19,6 @@ serde = { workspace = true, optional = true, features = ["derive", "alloc"] }
 # Revm + Alloy
 alloy-rlp.workspace = true
 alloy-trie.workspace = true
-alloy-consensus.workspace = true
 alloy-primitives = { workspace = true, features = ["rlp"] }
 
 [dev-dependencies]

--- a/crates/mpt/README.md
+++ b/crates/mpt/README.md
@@ -1,3 +1,18 @@
 # `kona-mpt`
 
-Utilities for interacting with a merkle patricia trie in the client program.
+<a href="https://github.com/anton-rs/kona/actions/workflows/rust_ci.yaml"><img src="https://github.com/anton-rs/kona/actions/workflows/rust_ci.yaml/badge.svg?label=ci" alt="CI"></a>
+<a href="https://crates.io/crates/kona-mpt"><img src="https://img.shields.io/crates/v/kona-mpt.svg?label=kona-mpt&labelColor=2a2f35" alt="Kona MPT"></a>
+<a href="https://github.com/anton-rs/kona/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/License-MIT-d1d1f6.svg?label=license&labelColor=2a2f35" alt="License"></a>
+<a href="https://img.shields.io/codecov/c/github/anton-rs/kona"><img src="https://img.shields.io/codecov/c/github/anton-rs/kona" alt="Codecov"></a>
+
+A recursive, in-memory implementation of Ethereum's hexary Merkle Patricia Trie (MPT), supporting:
+- Retrieval
+- Insertion
+- Deletion
+- Root Computation
+    - Trie Node RLP Encoding
+
+This implementation is intended to serve as a backend for a stateless executor of Ethereum blocks, like
+the one in the [`kona-executor`](../executor) crate. Starting with a trie root, the `TrieNode` can be
+unravelled to access, insert, or delete values. These operations are all backed by the `TrieProvider`,
+which enables fetching the preimages of hashed trie nodes.

--- a/crates/mpt/src/list_walker.rs
+++ b/crates/mpt/src/list_walker.rs
@@ -179,7 +179,7 @@ mod test {
     #[tokio::test]
     async fn test_online_list_walker_receipts() {
         let (root, preimages, envelopes) = get_live_derivable_receipts_list().await.unwrap();
-        let fetcher = TrieNodeProvider::new(preimages, BTreeMap::default(), BTreeMap::default());
+        let fetcher = TrieNodeProvider::new(preimages);
         let list = OrderedListWalker::try_new_hydrated(root, &fetcher).unwrap();
 
         assert_eq!(
@@ -193,7 +193,7 @@ mod test {
     #[tokio::test]
     async fn test_online_list_walker_transactions() {
         let (root, preimages, envelopes) = get_live_derivable_transactions_list().await.unwrap();
-        let fetcher = TrieNodeProvider::new(preimages, BTreeMap::default(), BTreeMap::default());
+        let fetcher = TrieNodeProvider::new(preimages);
         let list = OrderedListWalker::try_new_hydrated(root, &fetcher).unwrap();
 
         assert_eq!(
@@ -219,7 +219,7 @@ mod test {
             },
         );
 
-        let fetcher = TrieNodeProvider::new(preimages, BTreeMap::default(), BTreeMap::default());
+        let fetcher = TrieNodeProvider::new(preimages);
         let list = OrderedListWalker::try_new_hydrated(root, &fetcher).unwrap();
 
         assert_eq!(

--- a/crates/mpt/src/node.rs
+++ b/crates/mpt/src/node.rs
@@ -787,7 +787,7 @@ mod test {
                 acc
             },
         );
-        let fetcher = TrieNodeProvider::new(preimages, Default::default(), Default::default());
+        let fetcher = TrieNodeProvider::new(preimages);
 
         let mut root_node = fetcher.trie_node_by_hash(root).unwrap();
         for (i, value) in VALUES.iter().enumerate() {

--- a/crates/mpt/src/noop.rs
+++ b/crates/mpt/src/noop.rs
@@ -3,8 +3,7 @@
 
 use crate::{TrieHinter, TrieNode, TrieProvider};
 use alloc::string::String;
-use alloy_consensus::Header;
-use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_primitives::{Address, B256, U256};
 
 /// The default, no-op implementation of the [TrieProvider] trait, used for testing.
 #[derive(Debug, Clone, Copy)]
@@ -15,14 +14,6 @@ impl TrieProvider for NoopTrieProvider {
 
     fn trie_node_by_hash(&self, _key: B256) -> Result<TrieNode, Self::Error> {
         Ok(TrieNode::Empty)
-    }
-
-    fn bytecode_by_hash(&self, _code_hash: B256) -> Result<Bytes, Self::Error> {
-        Ok(Bytes::new())
-    }
-
-    fn header_by_hash(&self, _hash: B256) -> Result<Header, Self::Error> {
-        Ok(Header::default())
     }
 }
 

--- a/crates/mpt/src/test_util.rs
+++ b/crates/mpt/src/test_util.rs
@@ -125,17 +125,11 @@ pub(crate) async fn get_live_derivable_transactions_list(
 /// A mock [TrieProvider] for testing that serves in-memory preimages.
 pub(crate) struct TrieNodeProvider {
     preimages: BTreeMap<B256, Bytes>,
-    bytecode: BTreeMap<B256, Bytes>,
-    headers: BTreeMap<B256, alloy_consensus::Header>,
 }
 
 impl TrieNodeProvider {
-    pub(crate) const fn new(
-        preimages: BTreeMap<B256, Bytes>,
-        bytecode: BTreeMap<B256, Bytes>,
-        headers: BTreeMap<B256, alloy_consensus::Header>,
-    ) -> Self {
-        Self { preimages, bytecode, headers }
+    pub(crate) const fn new(preimages: BTreeMap<B256, Bytes>) -> Self {
+        Self { preimages }
     }
 }
 
@@ -152,13 +146,5 @@ impl TrieProvider for TrieNodeProvider {
                 .as_ref(),
         )
         .map_err(Into::into)
-    }
-
-    fn bytecode_by_hash(&self, hash: B256) -> Result<Bytes> {
-        self.bytecode.get(&hash).cloned().ok_or_else(|| anyhow!("Key not found"))
-    }
-
-    fn header_by_hash(&self, hash: B256) -> Result<alloy_consensus::Header> {
-        self.headers.get(&hash).cloned().ok_or_else(|| anyhow!("Key not found"))
     }
 }

--- a/crates/mpt/src/traits.rs
+++ b/crates/mpt/src/traits.rs
@@ -3,12 +3,10 @@
 
 use crate::TrieNode;
 use alloc::string::ToString;
-use alloy_consensus::Header;
-use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_primitives::{Address, B256, U256};
 use core::fmt::Display;
 
-/// The [TrieProvider] trait defines the synchronous interface for fetching trie node preimages and
-/// headers.
+/// The [TrieProvider] trait defines the synchronous interface for fetching trie node preimages.
 pub trait TrieProvider {
     /// The error type for fetching trie node preimages.
     type Error: Display + ToString;
@@ -21,33 +19,7 @@ pub trait TrieProvider {
     /// ## Returns
     /// - Ok(TrieNode): The trie node preimage.
     /// - Err(anyhow::Error): If the trie node preimage could not be fetched.
-    ///
-    /// [TrieDB]: crate::TrieDB
     fn trie_node_by_hash(&self, key: B256) -> Result<TrieNode, Self::Error>;
-
-    /// Fetches the preimage of the bytecode hash provided.
-    ///
-    /// ## Takes
-    /// - `hash`: The hash of the bytecode.
-    ///
-    /// ## Returns
-    /// - Ok(Bytes): The bytecode of the contract.
-    /// - Err(anyhow::Error): If the bytecode hash could not be fetched.
-    ///
-    /// [TrieDB]: crate::TrieDB
-    fn bytecode_by_hash(&self, code_hash: B256) -> Result<Bytes, Self::Error>;
-
-    /// Fetches the preimage of [Header] hash provided.
-    ///
-    /// ## Takes
-    /// - `hash`: The hash of the RLP-encoded [Header].
-    ///
-    /// ## Returns
-    /// - Ok(Bytes): The [Header].
-    /// - Err(anyhow::Error): If the [Header] could not be fetched.
-    ///
-    /// [TrieDB]: crate::TrieDB
-    fn header_by_hash(&self, hash: B256) -> Result<Header, Self::Error>;
 }
 
 /// The [TrieHinter] trait defines the synchronous interface for hinting the host to fetch trie


### PR DESCRIPTION
## Overview

Cleans up the leaky `TrieProvider` abstraction by extending the `TrieProvider` trait with the added functionality it needs to back a database rather than just a merkle patricia trie.

The `TrieProvider` trait served by `kona-mpt` now has a much simpler interface, just fetching trie node preimages.