### PR TITLE
chore(driver): Macro use tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3768,9 +3768,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.40"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -3853,9 +3853,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -3950,9 +3950,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "semver-parser"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
 dependencies = [
  "pest",
 ]

--- a/crates/driver/src/core.rs
+++ b/crates/driver/src/core.rs
@@ -5,16 +5,16 @@ use alloy_consensus::{BlockBody, Sealable};
 use alloy_primitives::B256;
 use alloy_rlp::Decodable;
 use core::fmt::Debug;
+use op_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType};
+use op_alloy_genesis::RollupConfig;
+use op_alloy_protocol::L2BlockInfo;
+use op_alloy_rpc_types_engine::OpAttributesWithParent;
+
 use kona_derive::{
     errors::{PipelineError, PipelineErrorKind},
     traits::{Pipeline, SignalReceiver},
     types::Signal,
 };
-use op_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType};
-use op_alloy_genesis::RollupConfig;
-use op_alloy_protocol::L2BlockInfo;
-use op_alloy_rpc_types_engine::OpAttributesWithParent;
-use tracing::{error, info, warn};
 
 use crate::{
     DriverError, DriverPipeline, DriverResult, Executor, ExecutorConstructor, PipelineCursor,

--- a/crates/driver/src/lib.rs
+++ b/crates/driver/src/lib.rs
@@ -9,6 +9,9 @@
 
 extern crate alloc;
 
+#[macro_use]
+extern crate tracing;
+
 mod errors;
 pub use errors::{DriverError, DriverResult};
 

--- a/crates/driver/src/pipeline.rs
+++ b/crates/driver/src/pipeline.rs
@@ -10,7 +10,6 @@ use kona_derive::{
     traits::{Pipeline, SignalReceiver},
     types::{ActivationSignal, ResetSignal, StepResult},
 };
-use tracing::{info, warn};
 
 /// The Driver's Pipeline
 ///


### PR DESCRIPTION
### Description

Adopts a nice pattern from reth to use tracing macros, removing the need to specify the dep each time.