### PR TITLE
chore(workspace): macro use tracing

### DIFF
--- a/crates/derive/src/lib.rs
+++ b/crates/derive/src/lib.rs
@@ -9,6 +9,9 @@
 
 extern crate alloc;
 
+#[macro_use]
+extern crate tracing;
+
 /// Required types and traits for kona's derivation pipeline.
 pub mod prelude {
     pub use crate::{

--- a/crates/derive/src/pipeline/core.rs
+++ b/crates/derive/src/pipeline/core.rs
@@ -13,7 +13,6 @@ use core::fmt::Debug;
 use op_alloy_genesis::{RollupConfig, SystemConfig};
 use op_alloy_protocol::{BlockInfo, L2BlockInfo};
 use op_alloy_rpc_types_engine::OpAttributesWithParent;
-use tracing::{error, trace, warn};
 
 /// The derivation pipeline is responsible for deriving L2 inputs from L1 data.
 #[derive(Debug)]

--- a/crates/derive/src/sources/blobs.rs
+++ b/crates/derive/src/sources/blobs.rs
@@ -11,7 +11,6 @@ use alloy_consensus::{Transaction, TxEip4844Variant, TxEnvelope, TxType};
 use alloy_primitives::{Address, Bytes};
 use async_trait::async_trait;
 use op_alloy_protocol::BlockInfo;
-use tracing::warn;
 
 /// A data iterator that reads from a blob.
 #[derive(Debug, Clone)]

--- a/crates/derive/src/stages/attributes_queue.rs
+++ b/crates/derive/src/stages/attributes_queue.rs
@@ -14,7 +14,6 @@ use core::fmt::Debug;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::{BlockInfo, L2BlockInfo, SingleBatch};
 use op_alloy_rpc_types_engine::{OpAttributesWithParent, OpPayloadAttributes};
-use tracing::info;
 
 /// [AttributesQueue] accepts batches from the [BatchQueue] stage
 /// and transforms them into [OpPayloadAttributes].

--- a/crates/derive/src/stages/batch/batch_queue.rs
+++ b/crates/derive/src/stages/batch/batch_queue.rs
@@ -13,7 +13,6 @@ use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::{
     Batch, BatchValidity, BatchWithInclusionBlock, BlockInfo, L2BlockInfo, SingleBatch,
 };
-use tracing::{error, info, warn};
 
 /// [BatchQueue] is responsible for o rdering unordered batches
 /// and gnerating empty batches when the sequence window has passed.

--- a/crates/derive/src/stages/batch/batch_stream.rs
+++ b/crates/derive/src/stages/batch/batch_stream.rs
@@ -13,7 +13,6 @@ use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::{
     Batch, BatchValidity, BatchWithInclusionBlock, BlockInfo, L2BlockInfo, SingleBatch, SpanBatch,
 };
-use tracing::{error, trace};
 
 /// Provides [Batch]es for the [BatchStream] stage.
 #[async_trait]

--- a/crates/derive/src/stages/batch/batch_validator.rs
+++ b/crates/derive/src/stages/batch/batch_validator.rs
@@ -12,7 +12,6 @@ use async_trait::async_trait;
 use core::fmt::Debug;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::{Batch, BatchValidity, BlockInfo, L2BlockInfo, SingleBatch};
-use tracing::{debug, error, info, warn};
 
 /// The [BatchValidator] stage is responsible for validating the [SingleBatch]es from
 /// the [BatchStream] [AttributesQueue]'s consumption.

--- a/crates/derive/src/stages/channel/channel_assembler.rs
+++ b/crates/derive/src/stages/channel/channel_assembler.rs
@@ -14,7 +14,6 @@ use op_alloy_genesis::{
     RollupConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD,
 };
 use op_alloy_protocol::{BlockInfo, Channel};
-use tracing::{debug, error, info, warn};
 
 /// The [ChannelAssembler] stage is responsible for assembling the [Frame]s from the [FrameQueue]
 /// stage into a raw compressed [Channel].

--- a/crates/derive/src/stages/channel/channel_bank.rs
+++ b/crates/derive/src/stages/channel/channel_bank.rs
@@ -13,7 +13,6 @@ use async_trait::async_trait;
 use core::fmt::Debug;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::{BlockInfo, Channel, ChannelId, Frame};
-use tracing::{trace, warn};
 
 /// The maximum size of a channel bank.
 pub(crate) const MAX_CHANNEL_BANK_SIZE: usize = 100_000_000;

--- a/crates/derive/src/stages/channel/channel_reader.rs
+++ b/crates/derive/src/stages/channel/channel_reader.rs
@@ -16,7 +16,6 @@ use op_alloy_genesis::{
     RollupConfig, MAX_RLP_BYTES_PER_CHANNEL_BEDROCK, MAX_RLP_BYTES_PER_CHANNEL_FJORD,
 };
 use op_alloy_protocol::{Batch, BlockInfo};
-use tracing::{debug, error, warn};
 
 /// ZLIB Deflate Compression Method.
 pub(crate) const ZLIB_DEFLATE_COMPRESSION_METHOD: u8 = 8;

--- a/crates/derive/src/stages/frame_queue.rs
+++ b/crates/derive/src/stages/frame_queue.rs
@@ -12,7 +12,6 @@ use async_trait::async_trait;
 use core::fmt::Debug;
 use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::{BlockInfo, Frame};
-use tracing::{debug, error, trace};
 
 /// Provides data frames for the [FrameQueue] stage.
 #[async_trait]

--- a/crates/derive/src/stages/l1_traversal.rs
+++ b/crates/derive/src/stages/l1_traversal.rs
@@ -11,7 +11,6 @@ use alloy_primitives::Address;
 use async_trait::async_trait;
 use op_alloy_genesis::{RollupConfig, SystemConfig};
 use op_alloy_protocol::BlockInfo;
-use tracing::warn;
 
 /// The [L1Traversal] stage of the derivation pipeline.
 ///

--- a/crates/driver/src/core.rs
+++ b/crates/driver/src/core.rs
@@ -5,16 +5,15 @@ use alloy_consensus::{BlockBody, Sealable};
 use alloy_primitives::B256;
 use alloy_rlp::Decodable;
 use core::fmt::Debug;
-use op_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType};
-use op_alloy_genesis::RollupConfig;
-use op_alloy_protocol::L2BlockInfo;
-use op_alloy_rpc_types_engine::OpAttributesWithParent;
-
 use kona_derive::{
     errors::{PipelineError, PipelineErrorKind},
     traits::{Pipeline, SignalReceiver},
     types::Signal,
 };
+use op_alloy_consensus::{OpBlock, OpTxEnvelope, OpTxType};
+use op_alloy_genesis::RollupConfig;
+use op_alloy_protocol::L2BlockInfo;
+use op_alloy_rpc_types_engine::OpAttributesWithParent;
 
 use crate::{
     DriverError, DriverPipeline, DriverResult, Executor, ExecutorConstructor, PipelineCursor,

--- a/crates/driver/src/cursor.rs
+++ b/crates/driver/src/cursor.rs
@@ -1,10 +1,11 @@
 //! Contains the cursor for the derivation pipeline.
 
-use crate::TipCursor;
 use alloc::collections::{btree_map::BTreeMap, vec_deque::VecDeque};
 use alloy_consensus::{Header, Sealed};
 use alloy_primitives::{map::HashMap, B256};
 use op_alloy_protocol::{BlockInfo, L2BlockInfo};
+
+use crate::TipCursor;
 
 /// A cursor that tracks the pipeline tip.
 #[derive(Debug, Clone)]

--- a/crates/driver/src/executor.rs
+++ b/crates/driver/src/executor.rs
@@ -1,13 +1,14 @@
 //! An abstraction for the driver's block executor.
 
-use alloc::string::ToString;
-use alloy_consensus::{Header, Sealed};
-use alloy_primitives::B256;
-use async_trait::async_trait;
 use core::{
     error::Error,
     fmt::{Debug, Display},
 };
+
+use alloc::string::ToString;
+use alloy_consensus::{Header, Sealed};
+use alloy_primitives::B256;
+use async_trait::async_trait;
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
 
 /// Executor

--- a/crates/executor/src/db/mod.rs
+++ b/crates/executor/src/db/mod.rs
@@ -12,7 +12,6 @@ use revm::{
     primitives::{AccountInfo, Bytecode, HashMap, BLOCK_HASH_HISTORY},
     Database,
 };
-use tracing::debug;
 
 mod account;
 pub use account::TrieAccount;

--- a/crates/executor/src/executor/mod.rs
+++ b/crates/executor/src/executor/mod.rs
@@ -20,7 +20,6 @@ use revm::{
     primitives::{calc_excess_blob_gas, EnvWithHandlerCfg},
     Evm,
 };
-use tracing::{debug, info};
 
 mod builder;
 pub use builder::{KonaHandleRegister, StatelessL2BlockExecutorBuilder};

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -9,6 +9,9 @@
 
 extern crate alloc;
 
+#[macro_use]
+extern crate tracing;
+
 mod errors;
 pub use errors::{ExecutorError, ExecutorResult, TrieDBError, TrieDBResult};
 

--- a/crates/proof-sdk/preimage/src/hint.rs
+++ b/crates/proof-sdk/preimage/src/hint.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use alloc::{boxed::Box, format, string::String, vec};
 use async_trait::async_trait;
-use tracing::{error, trace};
 
 /// A [HintWriter] is a high-level interface to the hint channel. It provides a way to write hints
 /// to the host.

--- a/crates/proof-sdk/preimage/src/lib.rs
+++ b/crates/proof-sdk/preimage/src/lib.rs
@@ -9,6 +9,9 @@
 
 extern crate alloc;
 
+#[macro_use]
+extern crate tracing;
+
 pub mod errors;
 
 mod key;

--- a/crates/proof-sdk/preimage/src/oracle.rs
+++ b/crates/proof-sdk/preimage/src/oracle.rs
@@ -4,7 +4,6 @@ use crate::{
     PreimageKey, PreimageOracleClient, PreimageOracleServer,
 };
 use alloc::{boxed::Box, vec::Vec};
-use tracing::trace;
 
 /// An [OracleReader] is a high-level interface to the preimage oracle channel.
 #[derive(Debug, Clone, Copy)]

--- a/crates/proof-sdk/proof/src/boot.rs
+++ b/crates/proof-sdk/proof/src/boot.rs
@@ -6,7 +6,6 @@ use alloy_primitives::{B256, U256};
 use kona_preimage::{PreimageKey, PreimageOracleClient};
 use op_alloy_genesis::RollupConfig;
 use serde::{Deserialize, Serialize};
-use tracing::warn;
 
 /// The local key ident for the L1 head hash.
 pub const L1_HEAD_KEY: U256 = U256::from_be_slice(&[1]);

--- a/crates/proof-sdk/proof/src/lib.rs
+++ b/crates/proof-sdk/proof/src/lib.rs
@@ -7,6 +7,9 @@
 
 extern crate alloc;
 
+#[macro_use]
+extern crate tracing;
+
 pub mod l1;
 
 pub mod l2;


### PR DESCRIPTION
### Description

Applies the `macro_use` with `tracing` across the workspace, less binaries.