### PR TITLE
docs: fix typo in custom-backend.md

### DIFF
--- a/book/src/sdk/custom-backend.md
+++ b/book/src/sdk/custom-backend.md
@@ -103,7 +103,7 @@ let cfg = RollupConfig::default();
 let provider = ...;
 let hinter = ...;
 
-let executor = StatelessL2BlcokExecutor::builder(&cfg, provider, hinter)
+let executor = StatelessL2BlockExecutor::builder(&cfg, provider, hinter)
    .with_parent_header(...)
    .build();
 


### PR DESCRIPTION
EDIT: this might be in a few places. Just realized its also in the other page: https://anton-rs.github.io/kona/sdk/exec-ext.html