### PR TITLE
chore: op-alloy 0.6.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,6 +2370,7 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-genesis",
  "op-alloy-protocol",
+ "op-alloy-registry",
  "op-alloy-rpc-types-engine",
  "proptest",
  "serde",
@@ -2515,6 +2516,7 @@ dependencies = [
  "op-alloy-consensus",
  "op-alloy-genesis",
  "op-alloy-protocol",
+ "op-alloy-registry",
  "op-alloy-rpc-types-engine",
  "serde",
  "serde_json",
@@ -2962,6 +2964,19 @@ dependencies = [
  "thiserror 2.0.3",
  "tracing",
  "unsigned-varint",
+]
+
+[[package]]
+name = "op-alloy-registry"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589e7906a7c8d71f06b130ee1d8a0a07b0b2cd0e0771157a770e6c20a34da953"
+dependencies = [
+ "alloy-primitives",
+ "lazy_static",
+ "op-alloy-genesis",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "7a73e9fe3c49d7afb2ace819fa181a287ce54a0983eda4e0eb05c22f82ffe534"
 
 [[package]]
 name = "jobserver"
@@ -2912,9 +2912,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72da577a88d35b893fae6467112651f26ef023434c196b2a0b3dc75bc853e0e4"
+checksum = "fce158d886815d419222daa67fcdf949a34f7950653a4498ebeb4963331f70ed"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2928,9 +2928,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-genesis"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818180672dd14ca6642fb57942e1cbd602669f42b6e0222b7ea9bbcae065d67e"
+checksum = "2734e9a65efb90fe4520303f984c124766b7d2f2e5dd51cbe54d6269c85a3c91"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2943,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-protocol"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1803a1ac96203b8f713b1fa9b7509c46c645ca7bc22b582761a7495e999d4301"
+checksum = "6c68a3e2770890da3ad2fd20d7fe0c8e15672707577b4168a60e388c8eceaca0"
 dependencies = [
  "alloc-no-stdlib",
  "alloy-consensus",
@@ -2966,9 +2966,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types-engine"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c227fcc7d81d4023363ba12406e57ebcc1c7cbb1075c38ea471ae32138d4706d"
+checksum = "864dbd5511ef4ef00b6c2c980739259b25b24048007b7751ca0069b30b1e3fee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4709,9 +4709,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ alloy-rpc-types-beacon = { version = "0.6.4", default-features = false }
 
 # OP Alloy
 op-alloy-genesis = { version = "0.6.8", default-features = false }
+op-alloy-registry = { version = "0.6.8", default-features = false }
 op-alloy-protocol = { version = "0.6.8", default-features = false }
 op-alloy-consensus = { version = "0.6.8", default-features = false }
 op-alloy-rpc-types-engine = { version = "0.6.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,10 +89,10 @@ alloy-rpc-types-engine = { version = "0.6.4", default-features = false }
 alloy-rpc-types-beacon = { version = "0.6.4", default-features = false }
 
 # OP Alloy
-op-alloy-genesis = { version = "0.6.7", default-features = false }
-op-alloy-protocol = { version = "0.6.7", default-features = false }
-op-alloy-consensus = { version = "0.6.7", default-features = false }
-op-alloy-rpc-types-engine = { version = "0.6.7", default-features = false }
+op-alloy-genesis = { version = "0.6.8", default-features = false }
+op-alloy-protocol = { version = "0.6.8", default-features = false }
+op-alloy-consensus = { version = "0.6.8", default-features = false }
+op-alloy-rpc-types-engine = { version = "0.6.8", default-features = false }
 
 # General
 lru = "0.12.4"

--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -44,6 +44,7 @@ tracing-subscriber = { workspace = true, optional = true, features = ["fmt"] }
 spin.workspace = true
 proptest.workspace = true
 serde_json.workspace = true
+op-alloy-registry.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 alloy-primitives = { workspace = true, features = ["rlp", "k256", "map", "arbitrary"] }

--- a/crates/derive/src/attributes/stateful.rs
+++ b/crates/derive/src/attributes/stateful.rs
@@ -12,7 +12,7 @@ use alloy_primitives::{address, Address, Bytes, B256};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_engine::PayloadAttributes;
 use async_trait::async_trait;
-use op_alloy_consensus::Hardforks;
+use op_alloy_consensus::{Hardfork, Hardforks};
 use op_alloy_genesis::RollupConfig;
 use op_alloy_protocol::{decode_deposit, L1BlockInfoTx, L2BlockInfo, DEPOSIT_EVENT_ABI_HASH};
 use op_alloy_rpc_types_engine::OpPayloadAttributes;
@@ -132,12 +132,12 @@ where
         if self.rollup_cfg.is_ecotone_active(next_l2_time) &&
             !self.rollup_cfg.is_ecotone_active(l2_parent.block_info.timestamp)
         {
-            upgrade_transactions = Hardforks::ecotone_txs();
+            upgrade_transactions = Hardforks::ECOTONE.txs().collect();
         }
         if self.rollup_cfg.is_fjord_active(next_l2_time) &&
             !self.rollup_cfg.is_fjord_active(l2_parent.block_info.timestamp)
         {
-            upgrade_transactions.append(&mut Hardforks::fjord_txs());
+            upgrade_transactions.append(&mut Hardforks::FJORD.txs().collect());
         }
 
         // Build and encode the L1 info transaction for the current payload.

--- a/crates/derive/src/stages/channel/channel_bank.rs
+++ b/crates/derive/src/stages/channel/channel_bank.rs
@@ -248,7 +248,6 @@ mod tests {
         types::ResetSignal,
     };
     use alloc::{vec, vec::Vec};
-    use op_alloy_genesis::{BASE_MAINNET_CONFIG, OP_MAINNET_CONFIG};
     use tracing::Level;
     use tracing_subscriber::layer::SubscriberExt;
 
@@ -508,9 +507,12 @@ mod tests {
         let subscriber = tracing_subscriber::Registry::default().with(layer);
         let _guard = tracing::subscriber::set_default(subscriber);
 
-        const ROLLUP_CONFIGS: [RollupConfig; 2] = [OP_MAINNET_CONFIG, BASE_MAINNET_CONFIG];
+        let configs: [RollupConfig; 2] = [
+            op_alloy_registry::ROLLUP_CONFIGS.get(&10).cloned().unwrap(),
+            op_alloy_registry::ROLLUP_CONFIGS.get(&8453).cloned().unwrap(),
+        ];
 
-        for cfg in ROLLUP_CONFIGS {
+        for cfg in configs {
             let frames = [
                 crate::frame!(0xFF, 0, vec![0xDD; 50], false),
                 crate::frame!(0xFF, 1, vec![0xDD; 50], true),

--- a/crates/proof-sdk/proof/Cargo.toml
+++ b/crates/proof-sdk/proof/Cargo.toml
@@ -26,6 +26,7 @@ alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 
 # Op Alloy
+op-alloy-registry.workspace = true
 op-alloy-protocol.workspace = true
 op-alloy-consensus.workspace = true
 op-alloy-rpc-types-engine.workspace = true

--- a/crates/proof-sdk/proof/src/boot.rs
+++ b/crates/proof-sdk/proof/src/boot.rs
@@ -5,6 +5,7 @@ use crate::errors::OracleProviderError;
 use alloy_primitives::{B256, U256};
 use kona_preimage::{PreimageKey, PreimageOracleClient};
 use op_alloy_genesis::RollupConfig;
+use op_alloy_registry::ROLLUP_CONFIGS;
 use serde::{Deserialize, Serialize};
 
 /// The local key ident for the L1 head hash.
@@ -104,8 +105,8 @@ impl BootInfo {
 
         // Attempt to load the rollup config from the chain ID. If there is no config for the chain,
         // fall back to loading the config from the preimage oracle.
-        let rollup_config = if let Some(config) = RollupConfig::from_l2_chain_id(chain_id) {
-            config
+        let rollup_config = if let Some(config) = ROLLUP_CONFIGS.get(&chain_id) {
+            config.clone()
         } else {
             warn!(
                 target: "boot-loader",


### PR DESCRIPTION
### Description

Bumps `op-alloy` deps to `0.6.8`, using the `op-alloy-registry` for rollup config digestion.