### PR TITLE
fix(`IndexedBlobHash`): Change `index` to `u64` 

### DIFF
--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -187,7 +187,7 @@ where
                 let timestamp = u64::from_be_bytes(timestamp_data_bytes);
 
                 let partial_block_ref = BlockInfo { timestamp, ..Default::default() };
-                let indexed_hash = IndexedBlobHash { index: index as usize, hash };
+                let indexed_hash = IndexedBlobHash { index, hash };
 
                 // Fetch the blob sidecar from the blob provider.
                 let mut sidecars = self

--- a/bin/host/src/providers/beacon.rs
+++ b/bin/host/src/providers/beacon.rs
@@ -128,7 +128,7 @@ impl BeaconClient for OnlineBeaconClient {
         let mut sidecars = Vec::with_capacity(hashes.len());
         hashes.iter().for_each(|hash| {
             if let Some(sidecar) =
-                raw_response.data.iter().find(|sidecar| sidecar.index == hash.index as u64)
+                raw_response.data.iter().find(|sidecar| sidecar.index == hash.index)
             {
                 sidecars.push(sidecar.clone());
             }

--- a/bin/host/src/providers/blob.rs
+++ b/bin/host/src/providers/blob.rs
@@ -314,7 +314,7 @@ where
                         ))?;
                         match sidecar.verify_blob(&alloy_eips::eip4844::IndexedBlobHash {
                             hash: hash.hash,
-                            index: hash.index as u64,
+                            index: hash.index,
                         }) {
                             Ok(_) => Ok(sidecar.blob),
                             Err(e) => Err(BlobProviderError::Backend(e.to_string())),

--- a/bin/host/src/providers/blob.rs
+++ b/bin/host/src/providers/blob.rs
@@ -103,10 +103,10 @@ impl<B: BeaconClient> OnlineBlobProvider<B> {
         let sidecars = self.fetch_sidecars(slot, blob_hashes).await?;
 
         // Filter blob sidecars that match the indicies in the specified list.
-        let blob_hash_indicies = blob_hashes.iter().map(|b| b.index).collect::<Vec<usize>>();
+        let blob_hash_indicies = blob_hashes.iter().map(|b| b.index).collect::<Vec<u64>>();
         let filtered = sidecars
             .into_iter()
-            .filter(|s| blob_hash_indicies.contains(&(s.index as usize)))
+            .filter(|s| blob_hash_indicies.contains(&s.index))
             .collect::<Vec<_>>();
 
         // Validate the correct number of blob sidecars were retrieved.
@@ -158,7 +158,7 @@ where
                     .ok_or(BlobProviderError::Backend("Missing blob hash".to_string()))?;
                 match sidecar.verify_blob(&alloy_eips::eip4844::IndexedBlobHash {
                     hash: hash.hash,
-                    index: hash.index as u64,
+                    index: hash.index,
                 }) {
                     Ok(_) => Ok(sidecar.blob),
                     Err(e) => Err(BlobProviderError::Backend(e.to_string())),
@@ -253,7 +253,7 @@ impl<B: BeaconClient, F: BlobSidecarProvider> OnlineBlobProviderWithFallback<B, 
         let blob_hash_indicies = blob_hashes.iter().map(|b| b.index).collect::<Vec<_>>();
         let filtered = sidecars
             .into_iter()
-            .filter(|s| blob_hash_indicies.contains(&(s.index as usize)))
+            .filter(|s| blob_hash_indicies.contains(&s.index))
             .collect::<Vec<_>>();
 
         // Validate the correct number of blob sidecars were retrieved.

--- a/crates/derive/src/sources/blob_hash.rs
+++ b/crates/derive/src/sources/blob_hash.rs
@@ -7,7 +7,7 @@ use alloy_primitives::B256;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IndexedBlobHash {
     /// The index of the blob
-    pub index: usize,
+    pub index: u64,
     /// The hash of the blob
     pub hash: B256,
 }

--- a/crates/derive/src/sources/blobs.rs
+++ b/crates/derive/src/sources/blobs.rs
@@ -106,7 +106,7 @@ where
                 continue;
             };
             for blob in blob_hashes {
-                let indexed = IndexedBlobHash { hash: blob, index: number as usize };
+                let indexed = IndexedBlobHash { hash: blob, index: number };
                 hashes.push(indexed);
                 data.push(BlobData::default());
                 number += 1;


### PR DESCRIPTION
On 64-bit architectures the behavior of `to_be_bytes` for `usize` and `u32` is the same, but in 32-bit architectures (e.g. SP1), `to_be_bytes` for a `usize` outputs 4 bytes instead of the expected 8 bytes.

This leads to the following error when getting blobs:

```shell
stderr: thread '<unnamed>' panicked at kona-d482f77e14858878/fd084b6/crates/proof-sdk/proof/src/l1/blob_provider.rs:41:31:
stderr: source slice length (4) does not match destination slice length (8)
stderr: stack backtrace:
stderr: note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
2024-11-26T19:26:01.928084Z  INFO execute: close time.busy=84.2s time.idle=20.0µs
thread 'main' panicked at /home/ubuntu/deployment-op-succinct/scripts/prove/src/lib.rs:44:10:
called `Result::unwrap()` on an `Err` value: execution failed with exit code 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Asterisc is a 64-bit architecture, which is why I think this issue wasn't caught: https://github.com/ethereum-optimism/asterisc.

Can we add CI for running a `kona` program in a 32-bit architecture? Happy to make a PR to ensure that consumers of `kona` (e.g. `op-succinct`) aren't impacted.