### PR TITLE
fix: use non problematic hashmap fns

### DIFF
--- a/bin/host/src/fetcher/mod.rs
+++ b/bin/host/src/fetcher/mod.rs
@@ -527,7 +527,7 @@ where
                     .await
                     .map_err(|e| anyhow!("Failed to fetch preimage: {e}"))?;
 
-                let mut merged = HashMap::<B256, Bytes>::new();
+                let mut merged = HashMap::<B256, Bytes>::default();
                 merged.extend(execute_payload_response.state);
                 merged.extend(execute_payload_response.codes);
                 merged.extend(execute_payload_response.keys);

--- a/crates/executor/src/syscalls/canyon.rs
+++ b/crates/executor/src/syscalls/canyon.rs
@@ -49,7 +49,7 @@ where
         revm_acc.mark_touch();
 
         // Commit the create2 deployer account to the database.
-        db.commit(HashMap::from([(CREATE_2_DEPLOYER_ADDR, revm_acc)]));
+        db.commit(HashMap::from_iter([(CREATE_2_DEPLOYER_ADDR, revm_acc)]));
         return Ok(());
     }
 


### PR DESCRIPTION
with alloy::map we need to be a bit careful with which hashmap functions we are using because some fns enforce certain hashers.

for example `From` is only implemented for `Randomstate`, which itself calls `from_iter` which only enforces ` S: BuildHasher + Default,`