### PR TITLE
feat(workspace): Bump MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 edition = "2021"
 license = "MIT"
-rust-version = "1.81"
+rust-version = "1.83"
 authors = ["clabby", "refcell"]
 homepage = "https://github.com/anton-rs/kona"
 repository = "https://github.com/anton-rs/kona"

--- a/build/asterisc/asterisc-repro.dockerfile
+++ b/build/asterisc/asterisc-repro.dockerfile
@@ -76,7 +76,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   pkg-config
 
 # Install rust
-ENV RUST_VERSION=1.81.0
+ENV RUST_VERSION=1.83.0
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain ${RUST_VERSION} --component rust-src
 ENV PATH="/root/.cargo/bin:${PATH}"
 


### PR DESCRIPTION
## Overview

Bumps the MSRV to 1.83, since we're using some features that were unstable in 1.81