### PR TITLE
chore(ci): Distribute `linux/arm64` `kona-fpp` image

### DIFF
--- a/.github/workflows/kona_fpp_docker.yaml
+++ b/.github/workflows/kona_fpp_docker.yaml
@@ -3,10 +3,6 @@ name: Build and Publish Kona FPP Images
 on:
   workflow_dispatch:
     inputs:
-      kona_client_tag:
-        description: Tag for `kona` to build `kona-client`
-        required: true
-        type: string
       asterisc_tag:
         description: Tag for `asterisc` to build the prestate artifacts
         required: true
@@ -29,6 +25,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Authenticate with container registry
         uses: docker/login-action@v3
         with:
@@ -46,9 +46,9 @@ jobs:
           file: build/${{ matrix.fpvm }}/${{ matrix.fpvm }}-repro.dockerfile
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
           build-args: |
-            CLIENT_TAG=${{ inputs.kona_client_tag }}
+            CLIENT_TAG=${{ github.ref_name }}
             ASTERISC_TAG=${{ inputs.asterisc_tag }}


### PR DESCRIPTION
# Overview

Adds a task for publishing the `kona-fpp` image on multiple platforms (`linux/arm64` + `linux/amd64`).