### PR TITLE
chore: Reduce MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 edition = "2021"
 license = "MIT"
-rust-version = "1.83"
+rust-version = "1.81"
 authors = ["clabby", "refcell"]
 homepage = "https://github.com/anton-rs/kona"
 repository = "https://github.com/anton-rs/kona"

--- a/build/asterisc/asterisc-repro.dockerfile
+++ b/build/asterisc/asterisc-repro.dockerfile
@@ -76,7 +76,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   pkg-config
 
 # Install rust
-ENV RUST_VERSION=1.83.0
+ENV RUST_VERSION=1.81.0
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain ${RUST_VERSION} --component rust-src
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/crates/derive/src/attributes/stateful.rs
+++ b/crates/derive/src/attributes/stateful.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unnecessary_map_or)]
 //! The [`AttributesBuilder`] and it's default implementation.
 
 use crate::{
@@ -214,7 +215,7 @@ async fn derive_deposits(
         for l in r.logs.iter() {
             let curr_index = global_index;
             global_index += 1;
-            if l.data.topics().first().is_none_or(|i| *i != DEPOSIT_EVENT_ABI_HASH) {
+            if l.data.topics().first().map_or(true, |i| *i != DEPOSIT_EVENT_ABI_HASH) {
                 continue;
             }
             if l.address != deposit_contract {

--- a/crates/derive/src/stages/batch/batch_validator.rs
+++ b/crates/derive/src/stages/batch/batch_validator.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unnecessary_map_or)]
 //! Contains the [BatchValidator] stage.
 
 use super::NextBatchProvider;
@@ -55,7 +56,7 @@ where
     /// ## Returns
     /// - `true` if the origin is behind the parent origin.
     fn origin_behind(&self, parent: &L2BlockInfo) -> bool {
-        self.prev.origin().is_none_or(|origin| origin.number < parent.l1_origin.number)
+        self.prev.origin().map_or(true, |origin| origin.number < parent.l1_origin.number)
     }
 
     /// Updates the [BatchValidator]'s view of the L1 origin blocks.


### PR DESCRIPTION
`is_none_or` is stable as of Rust 1.82, while the RISC Zero zkvm toolchain is currently using 1.81

This patch introduces more verbose code to bring the MSRV back down to 1.81 to avoid compiling with unstable features.

Generally it would also be great if Kona could have an MSRV policy set (e.g. MSRV is always at least 2 versions behind) to help avoid these issues.