### PR TITLE
feat(build): Adjust RV target - `riscv64g` -> `riscv64ima`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ see the [SDK section of the book](https://anton-rs.github.io/kona/sdk/intro.html
 **Build Pipelines**
 
 - [`cannon`](./build/cannon): Docker image for compiling to the bare-metal `mips-unknown-none` target.
-- [`asterisc`](./build/asterisc): Docker image for compiling to the bare-metal `riscv64gc-unknown-none-elf` target.
+- [`asterisc`](./build/asterisc): Docker image for compiling to the bare-metal `riscv64imac-unknown-none-elf` target.
 
 **Protocol**
 - [`mpt`](./crates/mpt): Utilities for interacting with the Merkle Patricia Trie in the client program.

--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -14,7 +14,7 @@ run-client-asterisc block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc ver
   OP_NODE_ADDRESS="{{rollup_node_rpc}}"
 
   HOST_BIN_PATH="./target/release/kona-host"
-  CLIENT_BIN_PATH="./target/riscv64gc-unknown-none-elf/release-client-lto/kona"
+  CLIENT_BIN_PATH="./target/riscv64imac-unknown-none-elf/release-client-lto/kona"
   STATE_PATH="./state.bin.gz"
 
   CLAIMED_L2_BLOCK_NUMBER={{block_number}}
@@ -133,7 +133,7 @@ run-client-asterisc-offline block_number l2_claim l2_output_root l2_head l1_head
   #!/usr/bin/env bash
 
   HOST_BIN_PATH="./target/release/kona-host"
-  CLIENT_BIN_PATH="./target/riscv64gc-unknown-none-elf/release-client-lto/kona"
+  CLIENT_BIN_PATH="./target/riscv64imac-unknown-none-elf/release-client-lto/kona"
   STATE_PATH="./state.bin.gz"
 
   CLAIMED_L2_BLOCK_NUMBER={{block_number}}

--- a/build/asterisc/asterisc-repro.dockerfile
+++ b/build/asterisc/asterisc-repro.dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends git
 # Build kona-client on the selected tag
 RUN git checkout $CLIENT_TAG && \
   cargo build -Zbuild-std=core,alloc --workspace --bin kona --locked --profile release-client-lto --exclude kona-host --exclude kona-derive-alloy && \
-  mv ./target/riscv64gc-unknown-none-elf/release-client-lto/kona /kona-client-elf
+  mv ./target/riscv64imac-unknown-none-elf/release-client-lto/kona /kona-client-elf
 
 ################################################################
 #                Build kona-host @ `CLIENT_TAG`                #

--- a/build/asterisc/asterisc.dockerfile
+++ b/build/asterisc/asterisc.dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
   clang \
   make \
   cmake \
-  git 
+  git
 
 # Install Rustup and Rust
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --default-toolchain ${RUST_VERSION} --component rust-src
@@ -29,5 +29,5 @@ ENV CC_riscv64_unknown_none_elf=riscv64-linux-gnu-gcc \
   CXX_riscv64_unknown_none_elf=riscv64-linux-gnu-g++ \
   CARGO_TARGET_RISCV64_UNKNOWN_NONE_ELF_LINKER=riscv64-linux-gnu-gcc \
   RUSTFLAGS="-Clink-arg=-e_start -Ctarget-feature=-c" \
-  CARGO_BUILD_TARGET="riscv64gc-unknown-none-elf" \
+  CARGO_BUILD_TARGET="riscv64imac-unknown-none-elf" \
   RUSTUP_TOOLCHAIN=${RUST_VERSION}

--- a/build/asterisc/asterisc.dockerfile
+++ b/build/asterisc/asterisc.dockerfile
@@ -28,6 +28,6 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 ENV CC_riscv64_unknown_none_elf=riscv64-linux-gnu-gcc \
   CXX_riscv64_unknown_none_elf=riscv64-linux-gnu-g++ \
   CARGO_TARGET_RISCV64_UNKNOWN_NONE_ELF_LINKER=riscv64-linux-gnu-gcc \
-  RUSTFLAGS="-Clink-arg=-e_start -Ctarget-feature=-c" \
+  RUSTFLAGS="-Clink-arg=-e_start -Ctarget-feature=-c,-zicsr,-zifencei,-zicntr,zihpm" \
   CARGO_BUILD_TARGET="riscv64imac-unknown-none-elf" \
   RUSTUP_TOOLCHAIN=${RUST_VERSION}

--- a/crates/proof-sdk/std-fpvm/src/riscv64/mod.rs
+++ b/crates/proof-sdk/std-fpvm/src/riscv64/mod.rs
@@ -1,4 +1,4 @@
-//! This module contains raw syscall bindings for the `riscv64gc` target architecture, as well as a
+//! This module contains raw syscall bindings for the `riscv64imac` target architecture, as well as a
 //! high-level implementation of the [crate::BasicKernelInterface] trait for the kernel.
 
 pub(crate) mod io;

--- a/crates/proof-sdk/std-fpvm/src/riscv64/mod.rs
+++ b/crates/proof-sdk/std-fpvm/src/riscv64/mod.rs
@@ -1,5 +1,5 @@
-//! This module contains raw syscall bindings for the `riscv64imac` target architecture, as well as a
-//! high-level implementation of the [crate::BasicKernelInterface] trait for the kernel.
+//! This module contains raw syscall bindings for the `riscv64imac` target architecture, as well as
+//! a high-level implementation of the [crate::BasicKernelInterface] trait for the kernel.
 
 pub(crate) mod io;
 mod syscall;

--- a/justfile
+++ b/justfile
@@ -82,7 +82,7 @@ lint-asterisc:
     --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/anton-rs/kona/asterisc-builder:main cargo +nightly clippy -p kona-std-fpvm --all-features --target riscv64gc-unknown-linux-gnu -Zbuild-std=core,alloc -- -D warnings
+    ghcr.io/anton-rs/kona/asterisc-builder:main cargo +nightly clippy -p kona-std-fpvm --all-features --target riscv64imac-unknown-linux-gnu -Zbuild-std=core,alloc -- -D warnings
 
 # Lint the Rust documentation
 lint-docs:

--- a/justfile
+++ b/justfile
@@ -82,7 +82,7 @@ lint-asterisc:
     --platform linux/amd64 \
     -v `pwd`/:/workdir \
     -w="/workdir" \
-    ghcr.io/anton-rs/kona/asterisc-builder:main cargo +nightly clippy -p kona-std-fpvm --all-features --target riscv64imac-unknown-linux-gnu -Zbuild-std=core,alloc -- -D warnings
+    ghcr.io/anton-rs/kona/asterisc-builder:main cargo +nightly clippy -p kona-std-fpvm --all-features --target riscv64imac-unknown-none-elf -Zbuild-std=core,alloc -- -D warnings
 
 # Lint the Rust documentation
 lint-docs:


### PR DESCRIPTION
## Overview

> [!NOTE]
> I validated locally that this target works out fine for running on asterisc, but will need to cut a release of the `asterisc-builder` cross compilation image for this to pass CI. Will do after vaca.
>
> For anyone who wants to experiment with this, head over to the `build` dir, and build the asterisc image locally w/ `just asterisc`. Then, head over to the root `justfile`, and adjust the `build-asterisc` recipe to use the local `asterisc-pipeline:latest` image that was built in the previous step.
>
> Once this is done, head over to `bin/client`, and run kona on asterisc w/ `just run-client-asterisc` to use the new `riscv64ima` binary.
>
> **e: A new image was manually published. This is good to go.**

Adjusts the build pipeline to use `riscv64imac-unknown-none-elf` as the target rather than `riscv64gc`. We still turn off `c`ompressed instructions, but this target forces LLVM to use soft-float operations for any `f`loating point / `d`oubleword floating point operations.