### PR TITLE
tooling: make client justfile's commands take an optional rollup_config_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ monorepo/
 
 # Environment Variables
 .env
+
+# kona-host data-dir
+data/

--- a/bin/client/justfile
+++ b/bin/client/justfile
@@ -63,13 +63,21 @@ run-client-asterisc block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc ver
     {{verbosity}}
 
 # Run the client program natively with the host program attached.
-run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbosity='':
+run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc rollup_config_path='' verbosity='':
   #!/usr/bin/env bash
+  set -o errexit -o nounset -o pipefail
 
   L1_NODE_ADDRESS="{{l1_rpc}}"
   L1_BEACON_ADDRESS="{{l1_beacon_rpc}}"
   L2_NODE_ADDRESS="{{l2_rpc}}"
   OP_NODE_ADDRESS="{{rollup_node_rpc}}"
+
+  L2_CHAIN_ID=$(cast chain-id --rpc-url $L2_NODE_ADDRESS)
+  if [ -z "{{rollup_config_path}}" ]; then
+    CHAIN_ID_OR_ROLLUP_CONFIG_ARG="--l2-chain-id $L2_CHAIN_ID"
+  else
+    CHAIN_ID_OR_ROLLUP_CONFIG_ARG="--rollup-config-path $(realpath {{rollup_config_path}})"
+  fi
 
   CLAIMED_L2_BLOCK_NUMBER={{block_number}}
   echo "Fetching configuration for block #$CLAIMED_L2_BLOCK_NUMBER..."
@@ -82,7 +90,6 @@ run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbo
   AGREED_L2_HEAD_HASH=$(cast block --rpc-url $L2_NODE_ADDRESS $((CLAIMED_L2_BLOCK_NUMBER - 1)) --json | jq -r .hash)
   L1_ORIGIN_NUM=$(cast rpc --rpc-url $OP_NODE_ADDRESS "optimism_outputAtBlock" $(cast 2h $((CLAIMED_L2_BLOCK_NUMBER - 1))) | jq -r .blockRef.l1origin.number)
   L1_HEAD=$(cast block --rpc-url $L1_NODE_ADDRESS $((L1_ORIGIN_NUM + 30)) --json | jq -r .hash)
-  L2_CHAIN_ID=$(cast chain-id --rpc-url $L2_NODE_ADDRESS)
 
   # Move to the workspace root
   cd $(git rev-parse --show-toplevel)
@@ -94,12 +101,12 @@ run-client-native block_number l1_rpc l1_beacon_rpc l2_rpc rollup_node_rpc verbo
     --claimed-l2-output-root $CLAIMED_L2_OUTPUT_ROOT \
     --agreed-l2-output-root $AGREED_L2_OUTPUT_ROOT \
     --claimed-l2-block-number $CLAIMED_L2_BLOCK_NUMBER \
-    --l2-chain-id $L2_CHAIN_ID \
     --l1-node-address $L1_NODE_ADDRESS \
     --l1-beacon-address $L1_BEACON_ADDRESS \
     --l2-node-address $L2_NODE_ADDRESS \
     --native \
     --data-dir ./data \
+    $CHAIN_ID_OR_ROLLUP_CONFIG_ARG \
     {{verbosity}}
 
 # Run the client program natively with the host program attached, in offline mode.


### PR DESCRIPTION
Needed to target a devnet which doesnt have a standard chain_id. Might need to make the same change for the offline client target as well?

We use this to test the client against the docker devnet in op's monorepo:
```
# Run the client program natively with the host program attached, against the op-devnet.
run-client-native-against-devnet verbosity='' block_number='' rollup_config_path='':
  #!/usr/bin/env bash
  L1_RPC="http://127.0.0.1:8545"
  L1_BEACON_RPC="http://127.0.0.1:5052"
  L2_RPC="http://127.0.0.1:9545"
  ROLLUP_NODE_RPC="http://127.0.0.1:7545"
  ROLLUP_CONFIG_PATH="../../../optimism/.devnet/rollup.json"

  if [ -z "{{block_number}}" ]; then
    BLOCK_NUMBER=$(cast block finalized --json --rpc-url $L2_RPC | jq -r .number | cast 2d)
  else
    BLOCK_NUMBER={{block_number}}
  fi

  just run-client-native $BLOCK_NUMBER \
    $L1_RPC $L1_BEACON_RPC $L2_RPC $ROLLUP_NODE_RPC \
    $ROLLUP_CONFIG_PATH {{verbosity}}
```