### PR TITLE
fix(derive): make tests compile

### DIFF
--- a/crates/derive/Cargo.toml
+++ b/crates/derive/Cargo.toml
@@ -41,6 +41,7 @@ serde_json.workspace = true
 op-alloy-registry.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
+tracing = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["rlp", "k256", "map", "arbitrary"] }
 
 [features]


### PR DESCRIPTION
On main, running `cargo check -p kona-derive --tests` did not work, since the `std` feature for tracing was not enabled in tests. This enables tracing's `std` feature when it's a dev dependency.